### PR TITLE
Add PlayerChangedWorldListener to handle world changes

### DIFF
--- a/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
+++ b/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
@@ -18,6 +18,7 @@ import dev.twme.worldeditdisplay.display.RenderManager;
 import dev.twme.worldeditdisplay.lang.LanguageManager;
 import dev.twme.worldeditdisplay.listener.InboundPacketListener;
 import dev.twme.worldeditdisplay.listener.OutboundPacketListener;
+import dev.twme.worldeditdisplay.listener.PlayerChangedWorldListener;
 import dev.twme.worldeditdisplay.listener.PlayerJoinListener;
 import dev.twme.worldeditdisplay.listener.PlayerLocaleChangeListener;
 import dev.twme.worldeditdisplay.listener.PlayerQuitListener;
@@ -106,6 +107,7 @@ public final class WorldEditDisplay extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerLocaleChangeListener(this), this);
+        getServer().getPluginManager().registerEvents(new PlayerChangedWorldListener(this), this);
         
         // Register commands
         getCommand("wedisplayreload").setExecutor(new ReloadCommand(this));

--- a/src/main/java/dev/twme/worldeditdisplay/listener/PlayerChangedWorldListener.java
+++ b/src/main/java/dev/twme/worldeditdisplay/listener/PlayerChangedWorldListener.java
@@ -1,0 +1,39 @@
+package dev.twme.worldeditdisplay.listener;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.display.RenderManager;
+import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
+
+/**
+ * Handles players switching between worlds.
+ * When a viewer changes worlds, their shared/viewall renders are cleared and refreshed
+ * so that selections in the new world are properly displayed.
+ */
+public class PlayerChangedWorldListener implements Listener {
+
+    private final WorldEditDisplay plugin;
+
+    public PlayerChangedWorldListener(WorldEditDisplay plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        Player player = event.getPlayer();
+        RenderManager renderManager = plugin.getRenderManager();
+        if (renderManager == null) return;
+
+        // Clear shared/viewall renders (entities from old world are gone client-side).
+        // Then re-render: selections in the new world will re-appear if conditions are met.
+        FoliaScheduler.getEntityScheduler().execute(player, plugin, () -> {
+            if (!player.isOnline()) return;
+            renderManager.clearSharedRenders(player.getUniqueId());
+            renderManager.updateRender(player);
+        }, null, 1L);
+    }
+}


### PR DESCRIPTION
Introduce a listener that clears and refreshes renders when a player changes worlds, ensuring proper display of selections in the new environment.