### PR TITLE
feat(floodgate): add Floodgate support to detect Bedrock players and disable CUI messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
       <name>TWME Repository</name>
       <url>https://repo.twme.dev/snapshots</url>
     </repository>
+    <repository>
+      <id>opencollab-snapshot</id>
+      <url>https://repo.opencollab.dev/main/</url>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -135,6 +139,12 @@
       <artifactId>bstats-bukkit</artifactId>
       <version>3.2.1</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geysermc.floodgate</groupId>
+      <artifactId>api</artifactId>
+      <version>2.2.5-SNAPSHOT</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/dev/twme/worldeditdisplay/listener/OutboundPacketListener.java
+++ b/src/main/java/dev/twme/worldeditdisplay/listener/OutboundPacketListener.java
@@ -40,6 +40,12 @@ public class OutboundPacketListener implements PacketListener {
 
         PlayerData playerData = PlayerData.getPlayerData(player);
 
+        // Do not send CUI messages to Bedrock (Floodgate) players
+        if (playerData.isBedrockPlayer()) {
+            event.setCancelled(true);
+            return;
+        }
+
         // If debug mode, show the received WECUI message
         if (playerData.isDebugEnabled()) {
             MessageUtil.sendTranslated(player, "command.wedisplay.debug.cui_message", message);

--- a/src/main/java/dev/twme/worldeditdisplay/listener/PlayerJoinListener.java
+++ b/src/main/java/dev/twme/worldeditdisplay/listener/PlayerJoinListener.java
@@ -13,6 +13,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPl
 import dev.twme.worldeditdisplay.WorldEditDisplay;
 import dev.twme.worldeditdisplay.common.Constants;
 import dev.twme.worldeditdisplay.player.PlayerData;
+import dev.twme.worldeditdisplay.util.FloodgateUtil;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 
 /**
@@ -37,6 +38,11 @@ public class PlayerJoinListener implements Listener {
         // Set auto-rendering based on permissions
         PlayerData playerData = PlayerData.getPlayerData(player);
         playerData.setRenderingEnabled(player.hasPermission("worldeditdisplay.render.auto-enable"));
+
+        // Detect Floodgate Bedrock players and disable CUI for them
+        if (FloodgateUtil.isBedrockPlayer(player)) {
+            playerData.setBedrockPlayer(true);
+        }
 
         // Initialize viewall/label session defaults from permission nodes
         if (player.hasPermission("worldeditdisplay.use.view.defaultenable")) {

--- a/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
+++ b/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
@@ -28,6 +28,7 @@ public class PlayerData {
     private boolean isCuiEnabled = false;
     private boolean renderingEnabled = false; // default off; will enable on login if player has permission
     private boolean debugEnabled = false;
+    private boolean bedrockPlayer = false; // true if joined via Floodgate (GeyserMC)
 
     // Current single selection
     private Region currentRegion;
@@ -116,6 +117,20 @@ public class PlayerData {
      */
     public void setRenderingEnabled(boolean enabled) {
         this.renderingEnabled = enabled;
+    }
+
+    /**
+     * Check if this player is a Bedrock (Floodgate) player.
+     */
+    public boolean isBedrockPlayer() {
+        return bedrockPlayer;
+    }
+
+    /**
+     * Set whether this player is a Bedrock (Floodgate) player.
+     */
+    public void setBedrockPlayer(boolean bedrockPlayer) {
+        this.bedrockPlayer = bedrockPlayer;
     }
 
     /**

--- a/src/main/java/dev/twme/worldeditdisplay/util/FloodgateUtil.java
+++ b/src/main/java/dev/twme/worldeditdisplay/util/FloodgateUtil.java
@@ -1,0 +1,50 @@
+package dev.twme.worldeditdisplay.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.geysermc.floodgate.api.FloodgateApi;
+
+/**
+ * Utility for checking whether a player is a Bedrock client via Floodgate (GeyserMC).
+ * Floodgate is optional; if the plugin is not present all checks return false.
+ */
+public final class FloodgateUtil {
+
+    private static final boolean FLOODGATE_AVAILABLE;
+
+    static {
+        boolean available = false;
+        try {
+            Class.forName("org.geysermc.floodgate.api.FloodgateApi");
+            available = Bukkit.getPluginManager().getPlugin("floodgate") != null;
+        } catch (ClassNotFoundException ignored) {
+        }
+        FLOODGATE_AVAILABLE = available;
+    }
+
+    private FloodgateUtil() {
+        // utility class
+    }
+
+    /**
+     * Returns true if Floodgate is present on the server.
+     */
+    public static boolean isFloodgateAvailable() {
+        return FLOODGATE_AVAILABLE;
+    }
+
+    /**
+     * Returns true if the given player is a Bedrock (Floodgate) player.
+     * Returns false if Floodgate is not installed or the player is a Java player.
+     */
+    public static boolean isBedrockPlayer(Player player) {
+        if (!FLOODGATE_AVAILABLE || player == null) {
+            return false;
+        }
+        try {
+            return FloodgateApi.getInstance().isFloodgatePlayer(player.getUniqueId());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,8 @@ folia-supported: true
 authors: [ TWME-TW ]
 depend:
   - packetevents
+softdepend:
+  - floodgate
 
 commands:
   wedisplayreload:


### PR DESCRIPTION
Bedrock (GeyserMC/Floodgate) players do not support WorldEditCUI. This change detects such players on join and cancels outbound CUI packets for them to avoid errors. Floodgate is an optional soft dependency.