### PR TITLE
Add particle-based fallback for clients without TextDisplay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
       <id>opencollab-snapshot</id>
       <url>https://repo.opencollab.dev/main/</url>
     </repository>
+    <repository>
+      <id>viaversion-repo</id>
+      <url>https://repo.viaversion.com</url>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -144,6 +148,12 @@
       <groupId>org.geysermc.floodgate</groupId>
       <artifactId>api</artifactId>
       <version>2.2.5-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.viaversion</groupId>
+      <artifactId>viaversion-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
             <configuration>
               <filters>
                 <!--
-                  Spigot profile only shades adventure-api for the SERIALIZER interfaces
-                  (ComponentSerializer, FlattenerListener, etc.) that packetevents relocates
-                  away. The core adventure classes (Component, TextComponentImpl, etc.) are
-                  intentionally excluded so that both WED and packetevents use the SAME class
-                  loaded by packetevents' classloader, avoiding ClassCastException.
-                  Paper profile: adventure-api is "provided" so this filter has no effect.
+                  Share core adventure-api classes from packetevents' classloader to
+                  avoid ClassCastException when EntityLib passes Component objects to
+                  packetevents APIs (e.g. EntityDataType.write()).
+                  Only serializer/flattener/builder classes are shaded into WED.
+                  Both use adventure 4.x so there is no API mismatch.
+                  Paper profile: adventure-api is "provided" so this filter is a no-op.
                 -->
                 <filter>
                   <artifact>net.kyori:adventure-api</artifact>
@@ -197,20 +197,21 @@
         </dependency>
         <!-- Spigot's plugin classloader does NOT expose adventure-api to plugins;
              shade all adventure deps to make the jar self-contained.
-             EXCEPTION: adventure-key, examination-api/string are shaded by packetevents
-             at their original package paths → setting "provided" prevents loading the
-             same interface from two PluginClassLoaders (which causes LinkageError).
-             They are available via packetevents' classloader at runtime. -->
+             Core adventure-api classes (Component, etc.) are filtered out so they
+             are shared from packetevents' classloader, preventing ClassCastException
+             when EntityLib passes Component objects to packetevents APIs.
+             Both WED and packetevents use adventure 4.x → binary compatible.
+             adventure-key, examination-api/string are provided by packetevents. -->
         <dependency>
           <groupId>net.kyori</groupId>
           <artifactId>adventure-api</artifactId>
-          <version>5.1.1</version>
+          <version>4.17.0</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>net.kyori</groupId>
           <artifactId>adventure-key</artifactId>
-          <version>5.1.1</version>
+          <version>4.17.0</version>
           <scope>provided</scope>
         </dependency>
         <dependency>
@@ -228,13 +229,13 @@
         <dependency>
           <groupId>net.kyori</groupId>
           <artifactId>adventure-text-minimessage</artifactId>
-          <version>5.1.1</version>
+          <version>4.17.0</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>net.kyori</groupId>
           <artifactId>adventure-text-serializer-legacy</artifactId>
-          <version>5.1.1</version>
+          <version>4.17.0</version>
           <scope>compile</scope>
         </dependency>
         <!-- BungeeCord serializer: converts Adventure Component → BaseComponent[] to preserve click events -->

--- a/src/main/java/dev/twme/worldeditdisplay/command/PlayerSettingsCommand.java
+++ b/src/main/java/dev/twme/worldeditdisplay/command/PlayerSettingsCommand.java
@@ -64,6 +64,7 @@ public class PlayerSettingsCommand implements TabExecutor {
             case "lang", "language" -> handleLanguage(player, args);
             case "toggle" -> handleToggle(player);
             case "debug" -> handleDebug(player);
+            case "render" -> handleRender(player, args);
             case "share" -> {
                 if (!player.hasPermission("worldeditdisplay.use.share")) {
                     MessageUtil.sendTranslated(player, "general.no_permission");
@@ -245,6 +246,62 @@ public class PlayerSettingsCommand implements TabExecutor {
         return true;
     }
 
+    private boolean handleRender(Player player, String[] args) {
+        if (!player.hasPermission("worldeditdisplay.use.render")) {
+            MessageUtil.sendTranslated(player, "general.no_permission");
+            return true;
+        }
+
+        PlayerData data = PlayerData.getPlayerData(player);
+
+        if (args.length < 2) {
+            // Show current mode
+            PlayerData.RenderMode current = data.getRenderMode();
+            String modeName = switch (current) {
+                case AUTO -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_auto");
+                case TEXT_DISPLAY -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_text");
+                case PARTICLE -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_particle");
+            };
+            MessageUtil.sendTranslated(player, "command.wedisplay.render.current", modeName);
+            MessageUtil.sendTranslated(player, "command.wedisplay.render.usage");
+            return true;
+        }
+
+        String modeArg = args[1].toLowerCase();
+        PlayerData.RenderMode newMode;
+
+        switch (modeArg) {
+            case "auto" -> newMode = PlayerData.RenderMode.AUTO;
+            case "text", "textdisplay" -> newMode = PlayerData.RenderMode.TEXT_DISPLAY;
+            case "particle", "particles" -> newMode = PlayerData.RenderMode.PARTICLE;
+            case "toggle" -> {
+                // Cycle: AUTO → PARTICLE → TEXT_DISPLAY → AUTO
+                newMode = switch (data.getRenderMode()) {
+                    case AUTO -> PlayerData.RenderMode.PARTICLE;
+                    case PARTICLE -> PlayerData.RenderMode.TEXT_DISPLAY;
+                    case TEXT_DISPLAY -> PlayerData.RenderMode.AUTO;
+                };
+            }
+            default -> {
+                MessageUtil.sendTranslated(player, "command.wedisplay.render.usage");
+                return true;
+            }
+        }
+
+        data.setRenderMode(newMode);
+
+        String modeName = switch (newMode) {
+            case AUTO -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_auto");
+            case TEXT_DISPLAY -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_text");
+            case PARTICLE -> MessageUtil.getTranslated(player, "command.wedisplay.render.mode_particle");
+        };
+        MessageUtil.sendTranslated(player, "command.wedisplay.render.set", modeName);
+
+        // Refresh renderer so the change takes effect immediately
+        plugin.getRenderManager().refreshPlayerRenderer(player);
+        return true;
+    }
+
     // helpers
     private void showRendererSettings(Player player, String renderer, PlayerRenderSettings settings, @Nullable String highlightedSetting) {
         MessageUtil.sendTranslated(player, "command.wedisplay.show.renderer_title", renderer.toUpperCase());
@@ -351,6 +408,8 @@ public class PlayerSettingsCommand implements TabExecutor {
         MessageUtil.sendTranslated(player, "command.wedisplay.help.toggle_desc");
         MessageUtil.sendTranslated(player, "command.wedisplay.help.debug");
         MessageUtil.sendTranslated(player, "command.wedisplay.help.debug_desc");
+        MessageUtil.sendTranslated(player, "command.wedisplay.help.render");
+        MessageUtil.sendTranslated(player, "command.wedisplay.help.render_desc");
         MessageUtil.sendTranslated(player, "command.wedisplay.help.share");
         MessageUtil.sendTranslated(player, "command.wedisplay.help.share_desc");
         MessageUtil.sendTranslated(player, "command.wedisplay.help.view");
@@ -386,7 +445,7 @@ public class PlayerSettingsCommand implements TabExecutor {
 
     // Tab Completion
     private static final List<String> SUB_COMMANDS = Arrays.asList(
-            "set", "reset", "show", "reloadplayer", "lang", "language", "toggle", "debug", "share", "view");
+            "set", "reset", "show", "reloadplayer", "lang", "language", "toggle", "debug", "render", "share", "view");
 
     // second argument options
     private static final List<String> RENDERERS = Arrays.asList(
@@ -403,6 +462,8 @@ public class PlayerSettingsCommand implements TabExecutor {
             // first arg: subcommand
             completions = SUB_COMMANDS.stream()
                     .filter(cmd -> cmd.startsWith(args[0].toLowerCase()))
+                    .filter(cmd -> !cmd.equals("render")
+                            || sender.hasPermission("worldeditdisplay.use.render"))
                     .collect(Collectors.toList());
 
         } else if (args.length == 2) {
@@ -417,6 +478,11 @@ public class PlayerSettingsCommand implements TabExecutor {
                 // second arg: language code
                 completions = plugin.getLanguageManager().getAvailableLanguages().stream()
                         .filter(lang -> lang.startsWith(args[1].toLowerCase()))
+                        .collect(Collectors.toList());
+            } else if (subCommand.equals("render")) {
+                // second arg: render mode
+                completions = Arrays.asList("auto", "text", "particle", "toggle").stream()
+                        .filter(m -> m.startsWith(args[1].toLowerCase()))
                         .collect(Collectors.toList());
             } else if (subCommand.equals("share")) {
                 return shareCommand.tabComplete((Player) sender, args);

--- a/src/main/java/dev/twme/worldeditdisplay/config/RenderSettings.java
+++ b/src/main/java/dev/twme/worldeditdisplay/config/RenderSettings.java
@@ -111,6 +111,14 @@ public class RenderSettings {
     private float polyhedronVertexSize;
     private float polyhedronVertexThickness;
     
+    // === Particle Fallback 設定 ===
+    private boolean particleFallbackEnabled;
+    private int particleUpdateInterval;
+    private int particleMaxRenderDistance;
+    private double particleEdgeDensity;
+    private Color particlePoint1Color;
+    private Color particlePoint2Color;
+
     public RenderSettings(WorldEditDisplay plugin) {
         this.plugin = plugin;
         loadDefaults();
@@ -202,6 +210,14 @@ public class RenderSettings {
         polyhedronVertexSize = 1.0f;
         polyhedronVertexThickness = 0.03f;
 
+        // Particle fallback defaults
+        particleFallbackEnabled = true;
+        particleUpdateInterval = 10;
+        particleMaxRenderDistance = 64;
+        particleEdgeDensity = 2.0;
+        particlePoint1Color = ColorUtil.parseHexColor("#33CC33CC");
+        particlePoint2Color = ColorUtil.parseHexColor("#3333CCCC");
+
         viewAllDistanceBasedEnabled = true;
         viewAllMinDistance = 64.0;
         viewAllSizeMultiplier = 2.0;
@@ -218,6 +234,7 @@ public class RenderSettings {
             loadEllipsoidSettings(config.getConfigurationSection("renderer.ellipsoid"));
             loadPolygonSettings(config.getConfigurationSection("renderer.polygon"));
             loadPolyhedronSettings(config.getConfigurationSection("renderer.polyhedron"));
+            loadParticleFallbackSettings(config.getConfigurationSection("particle_fallback"));
             loadViewAllSettings(config);
         } catch (Exception e) {
             loadDefaults();
@@ -369,13 +386,32 @@ public class RenderSettings {
         polyhedronVertexThickness = (float) section.getDouble("vertex_thickness", polyhedronVertexThickness);
     }
     
+    private void loadParticleFallbackSettings(ConfigurationSection section) {
+        if (section == null) return;
+        particleFallbackEnabled = section.getBoolean("enabled", particleFallbackEnabled);
+        particleUpdateInterval = section.getInt("update_interval", particleUpdateInterval);
+        particleMaxRenderDistance = section.getInt("max_render_distance", particleMaxRenderDistance);
+        particleEdgeDensity = Math.max(0.25, Math.min(section.getDouble("edge_density", particleEdgeDensity), 4.0));
+        particlePoint1Color = getColor(section, "point1_color", particlePoint1Color);
+        particlePoint2Color = getColor(section, "point2_color", particlePoint2Color);
+    }
+
+    // ─── Particle fallback getters ──────────────────────────────────────────
+
+    public boolean isParticleFallbackEnabled() { return particleFallbackEnabled; }
+    public int getParticleUpdateInterval() { return particleUpdateInterval; }
+    public int getParticleMaxRenderDistance() { return particleMaxRenderDistance; }
+    public double getParticleEdgeDensity() { return particleEdgeDensity; }
+    public Color getParticlePoint1Color() { return particlePoint1Color; }
+    public Color getParticlePoint2Color() { return particlePoint2Color; }
+
     private Color getColor(ConfigurationSection section, String key, Color defaultValue) {
         String colorStr = section.getString(key);
         if (colorStr == null || colorStr.isEmpty()) return defaultValue;
         Color parsed = ColorUtil.parseHexColor(colorStr);
         return parsed != null ? parsed : defaultValue;
     }
-    
+
     // === Cuboid Getters ===
     public boolean isCuboidSeeThrough() { return cuboidSeeThrough; }
     public Color getCuboidEdgeColor() { return cuboidEdgeColor; }

--- a/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
@@ -19,6 +19,12 @@ import com.github.retrooper.packetevents.util.Vector3f;
 import dev.twme.worldeditdisplay.WorldEditDisplay;
 import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
 import dev.twme.worldeditdisplay.config.SharedRenderSettings;
+import dev.twme.worldeditdisplay.display.particle.ParticleCuboidRenderer;
+import dev.twme.worldeditdisplay.display.particle.ParticleCylinderRenderer;
+import dev.twme.worldeditdisplay.display.particle.ParticleEllipsoidRenderer;
+import dev.twme.worldeditdisplay.display.particle.ParticlePolygonRenderer;
+import dev.twme.worldeditdisplay.display.particle.ParticlePolyhedronRenderer;
+import dev.twme.worldeditdisplay.display.particle.ParticleRenderer;
 import dev.twme.worldeditdisplay.display.renderer.CuboidRenderer;
 import dev.twme.worldeditdisplay.display.renderer.CylinderRenderer;
 import dev.twme.worldeditdisplay.display.renderer.EllipsoidRenderer;
@@ -67,11 +73,24 @@ public class RenderManager {
     /** sharerId → last player name used to build labelComponentCache entry (invalidation key). */
     private final Map<UUID, String> labelComponentNames;
 
+    // ─── Particle fallback renderers (for clients < 1.19.4) ────────────────
+    private final Map<UUID, ParticleRenderer> mainParticleRenderers;
+    private final Map<UUID, Map<UUID, ParticleRenderer>> multiParticleRenderers;
+    /** viewer → (sharer → renderer) */
+    private final Map<UUID, Map<UUID, ParticleRenderer>> sharedParticleRenderers;
+    private TaskWrapper particleTickTask;
+
     @FunctionalInterface
     private interface RendererFactory {
         RegionRenderer create(Player player, PlayerRenderSettings settings);
     }
     private final Map<Class<? extends Region>, RendererFactory> rendererFactories;
+
+    @FunctionalInterface
+    private interface ParticleRendererFactory {
+        ParticleRenderer create(Player player, PlayerRenderSettings settings);
+    }
+    private final Map<Class<? extends Region>, ParticleRendererFactory> particleRendererFactories;
 
     private static final int SHARED_COLOR_ALPHA = 230;
     private static final float SHARED_MIN_HUE_DISTANCE = 0.12f;
@@ -91,8 +110,15 @@ public class RenderManager {
         this.labelComponentNames = new ConcurrentHashMap<>();
         this.rendererFactories = new HashMap<>();
 
+        this.mainParticleRenderers = new ConcurrentHashMap<>();
+        this.multiParticleRenderers = new ConcurrentHashMap<>();
+        this.sharedParticleRenderers = new ConcurrentHashMap<>();
+        this.particleRendererFactories = new HashMap<>();
+
         registerRendererFactories();
+        registerParticleRendererFactories();
         startRebaseTask();
+        startParticleTickTask();
         plugin.getLogger().info("RenderManager started");
     }
 
@@ -104,6 +130,15 @@ public class RenderManager {
         rendererFactories.put(PolyhedronRegion.class, (p, s) -> new PolyhedronRenderer(plugin, p, s));
 
         plugin.getLogger().info("renderer types registered: " + rendererFactories.size());
+    }
+
+    private void registerParticleRendererFactories() {
+        particleRendererFactories.put(CuboidRegion.class,     (p, s) -> new ParticleCuboidRenderer(plugin, p, s));
+        particleRendererFactories.put(CylinderRegion.class,   (p, s) -> new ParticleCylinderRenderer(plugin, p, s));
+        particleRendererFactories.put(EllipsoidRegion.class,  (p, s) -> new ParticleEllipsoidRenderer(plugin, p, s));
+        particleRendererFactories.put(PolygonRegion.class,    (p, s) -> new ParticlePolygonRenderer(plugin, p, s));
+        particleRendererFactories.put(PolyhedronRegion.class, (p, s) -> new ParticlePolyhedronRenderer(plugin, p, s));
+        plugin.getLogger().info("particle renderer types registered: " + particleRendererFactories.size());
     }
 
     /**
@@ -123,17 +158,48 @@ public class RenderManager {
             return;
         }
 
-        updateMainSelection(player, playerId, playerData.getSelection());
-        updateMultiSelections(player, playerId, playerData.getMultiRegions());
+        if (playerData.isParticleFallback()) {
+            updateParticleMainSelection(player, playerId, playerData.getSelection());
+            updateParticleMultiSelections(player, playerId, playerData.getMultiRegions());
+            // Shared selections for particle fallback viewers are handled in notifyViewersOfSharer
+            // via updateSharedSelections, which already branches inside.
+        } else {
+            updateMainSelection(player, playerId, playerData.getSelection());
+            updateMultiSelections(player, playerId, playerData.getMultiRegions());
+        }
         updateSharedSelections(player, playerId);
 
         // When this player's own selection changes, update renderers for all viewers
         notifyViewersOfSharer(player);
 
         if (playerData.isDebugEnabled()) {
-            int entityCount = getPlayerEntityCount(playerId);
-            MessageUtil.sendTranslated(player, "command.wedisplay.debug.entity_count", entityCount);
+            if (playerData.isParticleFallback()) {
+                int particleCount = getParticlePointCount(playerId);
+                MessageUtil.sendTranslated(player, "command.wedisplay.debug.particle_count", particleCount);
+            } else {
+                int entityCount = getPlayerEntityCount(playerId);
+                MessageUtil.sendTranslated(player, "command.wedisplay.debug.entity_count", entityCount);
+            }
         }
+    }
+
+    /**
+     * Returns the total number of particle points currently cached for this player
+     * across main and multi particle renderers.
+     */
+    public int getParticlePointCount(UUID playerId) {
+        int count = 0;
+        ParticleRenderer main = mainParticleRenderers.get(playerId);
+        if (main != null) {
+            count += main.getPointCount();
+        }
+        Map<UUID, ParticleRenderer> multi = multiParticleRenderers.get(playerId);
+        if (multi != null) {
+            for (ParticleRenderer r : multi.values()) {
+                count += r.getPointCount();
+            }
+        }
+        return count;
     }
 
     /**
@@ -144,11 +210,24 @@ public class RenderManager {
         ShareManager shareManager = plugin.getShareManager();
         if (shareManager == null) return;
 
+        PlayerData viewerData = PlayerData.getPlayerData(viewer);
+        boolean viewerIsParticle = viewerData != null && viewerData.isParticleFallback();
+
         Set<UUID> sharers = resolveVisibleSharers(viewer, viewerId);
+
+        if (viewerIsParticle) {
+            updateSharedParticleSelections(viewer, viewerId, sharers, shareManager);
+        } else {
+            updateSharedTextDisplaySelections(viewer, viewerId, sharers, shareManager);
+        }
+    }
+
+    /** Shared-selection path for TextDisplay viewers (>= 1.19.4). */
+    private void updateSharedTextDisplaySelections(Player viewer, UUID viewerId,
+                                                    Set<UUID> sharers, ShareManager shareManager) {
         Map<UUID, RegionRenderer> viewerSharedRenderers =
                 sharedRenderers.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
 
-        // Remove renderers for sharers no longer in the visible list
         viewerSharedRenderers.entrySet().removeIf(e -> {
             if (!sharers.contains(e.getKey())) {
                 e.getValue().clear();
@@ -160,13 +239,58 @@ public class RenderManager {
 
         Vector3 viewerPos = null;
         for (UUID sharerId : sharers) {
-            // Distance-based loading for viewall-sourced players (not for active shares)
             if (!shareManager.isActiveShare(sharerId, viewerId)) {
                 if (viewerPos == null) viewerPos = Vector3.from(viewer.getLocation());
                 if (!shouldRenderForViewAll(viewer, sharerId, viewerPos)) continue;
             }
             Color sharedColor = getOrCreateSharedColor(sharerId);
             renderSharedForViewer(viewer, viewerSharedRenderers, sharerId, sharedColor, false);
+        }
+    }
+
+    /** Shared-selection path for particle-fallback viewers (< 1.19.4). */
+    private void updateSharedParticleSelections(Player viewer, UUID viewerId,
+                                                 Set<UUID> sharers, ShareManager shareManager) {
+        Map<UUID, ParticleRenderer> viewerShared =
+                sharedParticleRenderers.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
+
+        viewerShared.entrySet().removeIf(e -> {
+            if (!sharers.contains(e.getKey())) {
+                e.getValue().clear();
+                releaseSharedColorIfUnused(e.getKey());
+                return true;
+            }
+            return false;
+        });
+
+        int maxParticleDist = plugin.getRenderSettings().getParticleMaxRenderDistance();
+
+        Vector3 viewerPos = null;
+        for (UUID sharerId : sharers) {
+            Player sharer = Bukkit.getPlayer(sharerId);
+            if (sharer == null || !sharer.isOnline()) continue;
+
+            // Distance check: apply max_render_distance as an absolute cap for ALL particle shares
+            if (viewerPos == null) viewerPos = Vector3.from(viewer.getLocation());
+            PlayerData sharerData = PlayerData.getPlayerData(sharer);
+            Region sharerRegion = sharerData != null ? sharerData.getSelection() : null;
+
+            double distance;
+            if (sharerRegion != null && sharerRegion.getBoundingBox() != null) {
+                distance = sharerRegion.getBoundingBox().distanceTo(viewerPos);
+            } else {
+                distance = viewer.getLocation().distance(sharer.getLocation());
+            }
+
+            if (distance > maxParticleDist) continue;
+
+            // For viewall-sourced players, also apply viewall distance-based loading
+            if (!shareManager.isActiveShare(sharerId, viewerId)) {
+                if (!shouldRenderForViewAll(viewer, sharerId, viewerPos)) continue;
+            }
+
+            Color sharedColor = getOrCreateSharedColor(sharerId);
+            renderSharedParticleForViewer(viewer, viewerShared, sharerId, sharedColor, false);
         }
     }
 
@@ -264,10 +388,19 @@ public class RenderManager {
                 if (viewerData != null && viewerData.isViewAllHidden(sharer.getUniqueId())) continue;
             }
 
-            Map<UUID, RegionRenderer> viewerSharedRenderers =
-                    sharedRenderers.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
             Color color = getOrCreateSharedColor(sharer.getUniqueId());
-            renderSharedForViewer(viewer, viewerSharedRenderers, sharer.getUniqueId(), color, true);
+            PlayerData viewerData = PlayerData.getPlayerData(viewer);
+            boolean viewerIsParticle = viewerData != null && viewerData.isParticleFallback();
+
+            if (viewerIsParticle) {
+                Map<UUID, ParticleRenderer> viewerShared =
+                        sharedParticleRenderers.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
+                renderSharedParticleForViewer(viewer, viewerShared, sharer.getUniqueId(), color, true);
+            } else {
+                Map<UUID, RegionRenderer> viewerSharedRenderers =
+                        sharedRenderers.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
+                renderSharedForViewer(viewer, viewerSharedRenderers, sharer.getUniqueId(), color, true);
+            }
         }
     }
 
@@ -331,6 +464,66 @@ public class RenderManager {
             // Do NOT clear dirty here – the sharer's own updateRender handles that
         } catch (Exception e) {
             plugin.getLogger().log(Level.SEVERE, "shared render fail for viewer " + viewer.getName(), e);
+        }
+    }
+
+    /**
+     * Particle-fallback equivalent of {@link #renderSharedForViewer}.
+     * Renders the sharer's region as coloured particles for a low-version viewer.
+     * All particles use REDSTONE DustOptions with the shared colour.
+     */
+    private void renderSharedParticleForViewer(Player viewer, Map<UUID, ParticleRenderer> viewerShared,
+                                                UUID sharerId, Color sharedColor, boolean forceRender) {
+        Player sharerPlayer = Bukkit.getPlayer(sharerId);
+        if (sharerPlayer == null || !sharerPlayer.isOnline()) {
+            ParticleRenderer r = viewerShared.remove(sharerId);
+            if (r != null) r.clear();
+            releaseSharedColorIfUnused(sharerId);
+            return;
+        }
+
+        PlayerData sharerData = PlayerData.getPlayerData(sharerPlayer);
+        if (sharerData == null) return;
+
+        Region sharerRegion = sharerData.getSelection();
+        if (sharerRegion == null) {
+            ParticleRenderer r = viewerShared.remove(sharerId);
+            if (r != null) r.clear();
+            releaseSharedColorIfUnused(sharerId);
+            return;
+        }
+
+        ParticleRenderer renderer = viewerShared.get(sharerId);
+
+        // Replace renderer if region type changed
+        if (renderer != null && !renderer.getRegionType().equals(sharerRegion.getClass())) {
+            renderer.clear();
+            viewerShared.remove(sharerId);
+            renderer = null;
+        }
+
+        if (!forceRender && renderer != null && !sharerRegion.isDirty()) {
+            return;
+        }
+
+        if (renderer == null) {
+            renderer = createParticleRenderer(viewer, sharerRegion);
+            if (renderer != null) {
+                renderer.setSharedColor(sharedColor);
+                renderer.addViewer(viewer.getUniqueId());
+                viewerShared.put(sharerId, renderer);
+            } else {
+                return;
+            }
+        }
+
+        try {
+            renderer.render(sharerRegion);
+            renderer.postRender();
+            // Do NOT clear dirty here – the sharer's own updateRender handles that
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "shared particle render fail for viewer "
+                    + viewer.getName(), e);
         }
     }
 
@@ -511,11 +704,22 @@ public class RenderManager {
 
     /** Clear all shared renderers for a specific viewer. */
     public void clearSharedRenders(UUID viewerId) {
+        // TextDisplay shared renderers
         Map<UUID, RegionRenderer> map = sharedRenderers.remove(viewerId);
         if (map != null) {
             Set<UUID> sharerIds = Set.copyOf(map.keySet());
             map.values().forEach(RegionRenderer::clear);
             map.clear();
+            for (UUID sharerId : sharerIds) {
+                releaseSharedColorIfUnused(sharerId);
+            }
+        }
+        // Particle shared renderers
+        Map<UUID, ParticleRenderer> particleMap = sharedParticleRenderers.remove(viewerId);
+        if (particleMap != null) {
+            Set<UUID> sharerIds = Set.copyOf(particleMap.keySet());
+            particleMap.values().forEach(ParticleRenderer::clear);
+            particleMap.clear();
             for (UUID sharerId : sharerIds) {
                 releaseSharedColorIfUnused(sharerId);
             }
@@ -528,6 +732,7 @@ public class RenderManager {
      * and releases associated colour / component cache state.
      */
     public void clearSharerRenders(UUID sharerId) {
+        // TextDisplay shared renderers
         for (Map.Entry<UUID, Map<UUID, RegionRenderer>> entry : sharedRenderers.entrySet()) {
             UUID viewerId = entry.getKey();
             Map<UUID, RegionRenderer> viewerMap = entry.getValue();
@@ -535,6 +740,14 @@ public class RenderManager {
             if (renderer != null) renderer.clear();
             if (viewerMap.isEmpty()) sharedRenderers.remove(viewerId);
             clearSharedLabel(viewerId, sharerId);
+        }
+        // Particle shared renderers
+        for (Map.Entry<UUID, Map<UUID, ParticleRenderer>> entry : sharedParticleRenderers.entrySet()) {
+            UUID viewerId = entry.getKey();
+            Map<UUID, ParticleRenderer> viewerMap = entry.getValue();
+            ParticleRenderer renderer = viewerMap.remove(sharerId);
+            if (renderer != null) renderer.clear();
+            if (viewerMap.isEmpty()) sharedParticleRenderers.remove(viewerId);
         }
         // The sharer is offline – release colour and component cache unconditionally.
         sharedColors.remove(sharerId);
@@ -544,12 +757,22 @@ public class RenderManager {
 
     /** Clear the shared renderer a specific viewer has for a specific sharer. */
     public void clearSharedRender(UUID viewerId, UUID sharerId) {
+        // TextDisplay
         Map<UUID, RegionRenderer> map = sharedRenderers.get(viewerId);
         if (map != null) {
             RegionRenderer r = map.remove(sharerId);
             if (r != null) r.clear();
             if (map.isEmpty()) {
                 sharedRenderers.remove(viewerId);
+            }
+        }
+        // Particle
+        Map<UUID, ParticleRenderer> particleMap = sharedParticleRenderers.get(viewerId);
+        if (particleMap != null) {
+            ParticleRenderer r = particleMap.remove(sharerId);
+            if (r != null) r.clear();
+            if (particleMap.isEmpty()) {
+                sharedParticleRenderers.remove(viewerId);
             }
         }
         releaseSharedColorIfUnused(sharerId);
@@ -562,20 +785,31 @@ public class RenderManager {
      */
     public void clearViewAllRenders(UUID viewerId) {
         ShareManager shareManager = plugin.getShareManager();
+        // TextDisplay
         Map<UUID, RegionRenderer> map = sharedRenderers.get(viewerId);
-        if (map == null) return;
-
-        map.entrySet().removeIf(e -> {
-            UUID sharerId = e.getKey();
-            // Keep if there is an active share relationship
-            if (shareManager != null && shareManager.isActiveShare(sharerId, viewerId)) return false;
-            e.getValue().clear();
-            releaseSharedColorIfUnused(sharerId);
-            clearSharedLabel(viewerId, sharerId);
-            return true;
-        });
-
-        if (map.isEmpty()) sharedRenderers.remove(viewerId);
+        if (map != null) {
+            map.entrySet().removeIf(e -> {
+                UUID sharerId = e.getKey();
+                if (shareManager != null && shareManager.isActiveShare(sharerId, viewerId)) return false;
+                e.getValue().clear();
+                releaseSharedColorIfUnused(sharerId);
+                clearSharedLabel(viewerId, sharerId);
+                return true;
+            });
+            if (map.isEmpty()) sharedRenderers.remove(viewerId);
+        }
+        // Particle
+        Map<UUID, ParticleRenderer> particleMap = sharedParticleRenderers.get(viewerId);
+        if (particleMap != null) {
+            particleMap.entrySet().removeIf(e -> {
+                UUID sharerId = e.getKey();
+                if (shareManager != null && shareManager.isActiveShare(sharerId, viewerId)) return false;
+                e.getValue().clear();
+                releaseSharedColorIfUnused(sharerId);
+                return true;
+            });
+            if (particleMap.isEmpty()) sharedParticleRenderers.remove(viewerId);
+        }
     }
 
     /**
@@ -585,6 +819,13 @@ public class RenderManager {
         ShareManager shareManager = plugin.getShareManager();
         if (shareManager != null && shareManager.isActiveShare(sharerId, viewerId)) return;
         clearSharedRender(viewerId, sharerId);
+        // Also clear particle shared render if present
+        Map<UUID, ParticleRenderer> particleMap = sharedParticleRenderers.get(viewerId);
+        if (particleMap != null) {
+            ParticleRenderer r = particleMap.remove(sharerId);
+            if (r != null) r.clear();
+            if (particleMap.isEmpty()) sharedParticleRenderers.remove(viewerId);
+        }
     }
 
     private void updateMainSelection(Player player, UUID playerId, Region mainSelection) {
@@ -671,7 +912,103 @@ public class RenderManager {
         }
     }
 
+    private void updateParticleMainSelection(Player player, UUID playerId, Region mainSelection) {
+        // If the player switched from particle to TextDisplay (e.g. ViaVersion now reports >=1.19.4),
+        // ensure any stale particle renderer is cleaned up.
+        if (mainSelection == null || !player.isOnline()) {
+            clearParticleMainRender(playerId);
+            return;
+        }
+
+        ParticleRenderer currentRenderer = mainParticleRenderers.get(playerId);
+
+        if (currentRenderer != null && !currentRenderer.getRegionType().equals(mainSelection.getClass())) {
+            currentRenderer.clear();
+            mainParticleRenderers.remove(playerId);
+            currentRenderer = null;
+        }
+
+        if (currentRenderer == null) {
+            currentRenderer = createParticleRenderer(player, mainSelection);
+            if (currentRenderer != null) mainParticleRenderers.put(playerId, currentRenderer);
+            else {
+                plugin.getLogger().warning("cannot make particle renderer: " + mainSelection.getClass().getSimpleName());
+                return;
+            }
+        } else if (!mainSelection.isDirty()) {
+            return;
+        }
+
+        try {
+            currentRenderer.render(mainSelection);
+            currentRenderer.postRender();
+            mainSelection.clearDirty();
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "particle main render fail: " + player.getName(), e);
+        }
+    }
+
+    /**
+     * Remove the main particle renderer for a player (if any).
+     */
+    private void clearParticleMainRender(UUID playerId) {
+        ParticleRenderer renderer = mainParticleRenderers.remove(playerId);
+        if (renderer != null) renderer.clear();
+    }
+
+    // ─── Particle fallback: multi selections ─────────────────────────────
+
+    private void updateParticleMultiSelections(Player player, UUID playerId, Map<UUID, Region> multiRegions) {
+        Map<UUID, ParticleRenderer> playerMulti =
+                multiParticleRenderers.computeIfAbsent(playerId, k -> new ConcurrentHashMap<>());
+
+        // remove stale regions
+        playerMulti.keySet().removeIf(regionId -> {
+            if (!multiRegions.containsKey(regionId)) {
+                ParticleRenderer r = playerMulti.remove(regionId);
+                if (r != null) r.clear();
+                return true;
+            }
+            return false;
+        });
+
+        for (Map.Entry<UUID, Region> entry : multiRegions.entrySet()) {
+            UUID regionId = entry.getKey();
+            Region region = entry.getValue();
+            if (region == null) continue;
+
+            ParticleRenderer renderer = playerMulti.get(regionId);
+
+            if (renderer != null && !renderer.getRegionType().equals(region.getClass())) {
+                renderer.clear();
+                playerMulti.remove(regionId);
+                renderer = null;
+            }
+
+            if (renderer == null) {
+                renderer = createParticleRenderer(player, region);
+                if (renderer != null) playerMulti.put(regionId, renderer);
+                else {
+                    plugin.getLogger().warning("cannot make particle multi renderer: " + region.getClass().getSimpleName());
+                    continue;
+                }
+            } else if (!region.isDirty()) {
+                // renderer 已存在且 region 沒有變動，跳過
+                continue;
+            }
+
+            try {
+                renderer.render(region);
+                renderer.postRender();
+                region.clearDirty();
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.SEVERE, "multi render fail: " + player.getName(), e);
+            }
+        }
+    }
+
     public void clearRender(UUID playerId) {
+        // TextDisplay renderers
         RegionRenderer mainRenderer = mainRenderers.remove(playerId);
         if (mainRenderer != null) mainRenderer.clear();
 
@@ -679,6 +1016,14 @@ public class RenderManager {
         if (playerMultiRenderers != null) {
             playerMultiRenderers.values().forEach(RegionRenderer::clear);
             playerMultiRenderers.clear();
+        }
+
+        // Particle fallback renderers
+        clearParticleMainRender(playerId);
+        Map<UUID, ParticleRenderer> playerMultiParticle = multiParticleRenderers.remove(playerId);
+        if (playerMultiParticle != null) {
+            playerMultiParticle.values().forEach(ParticleRenderer::clear);
+            playerMultiParticle.clear();
         }
 
         // Clear shared renderers this player holds (selections they were watching as a viewer)
@@ -751,6 +1096,7 @@ public class RenderManager {
     }
 
     public void clearAllRenders() {
+        // TextDisplay renderers
         mainRenderers.values().forEach(RegionRenderer::clear);
         mainRenderers.clear();
 
@@ -769,6 +1115,22 @@ public class RenderManager {
 
         labelEntities.values().forEach(m -> m.values().forEach(WrapperEntity::remove));
         labelEntities.clear();
+
+        // Particle fallback renderers
+        mainParticleRenderers.values().forEach(ParticleRenderer::clear);
+        mainParticleRenderers.clear();
+
+        multiParticleRenderers.values().forEach(m -> {
+            m.values().forEach(ParticleRenderer::clear);
+            m.clear();
+        });
+        multiParticleRenderers.clear();
+
+        sharedParticleRenderers.values().forEach(m -> {
+            m.values().forEach(ParticleRenderer::clear);
+            m.clear();
+        });
+        sharedParticleRenderers.clear();
     }
 
     private RegionRenderer createRenderer(Player player, Region region) {
@@ -788,6 +1150,71 @@ public class RenderManager {
             plugin.getLogger().log(Level.SEVERE, "cannot create renderer: " + region.getClass().getSimpleName(), e);
             return null;
         }
+    }
+
+    private ParticleRenderer createParticleRenderer(Player player, Region region) {
+        return createParticleRenderer(player, region,
+                plugin.getPlayerSettingsManager().getSettings(player.getUniqueId()));
+    }
+
+    private ParticleRenderer createParticleRenderer(Player player, Region region,
+                                                     PlayerRenderSettings settings) {
+        ParticleRendererFactory factory = particleRendererFactories.get(region.getClass());
+        if (factory == null) {
+            plugin.getLogger().warning("particle renderer not found: " + region.getClass().getSimpleName());
+            return null;
+        }
+        try {
+            ParticleRenderer renderer = factory.create(player, settings);
+            if (renderer != null) {
+                renderer.applyServerSettings(plugin.getRenderSettings());
+            }
+            return renderer;
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "cannot create particle renderer: "
+                    + region.getClass().getSimpleName(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Starts a periodic task that sends particle points to all active particle-fallback viewers.
+     * Interval is read from the server config (particle_fallback.update_interval).
+     */
+    private void startParticleTickTask() {
+        int interval = plugin.getRenderSettings().getParticleUpdateInterval();
+        if (interval < 1) interval = 5;
+        plugin.getLogger().info("Particle fallback tick interval: " + interval + " ticks");
+        particleTickTask = FoliaScheduler.getGlobalRegionScheduler().runAtFixedRate(plugin, ignored -> {
+            // Main particle renderers
+            for (ParticleRenderer renderer : mainParticleRenderers.values()) {
+                try {
+                    renderer.tick();
+                } catch (Exception e) {
+                    plugin.getLogger().log(Level.WARNING, "particle main tick fail", e);
+                }
+            }
+            // Multi particle renderers
+            for (Map<UUID, ParticleRenderer> map : multiParticleRenderers.values()) {
+                for (ParticleRenderer renderer : map.values()) {
+                    try {
+                        renderer.tick();
+                    } catch (Exception e) {
+                        plugin.getLogger().log(Level.WARNING, "particle multi tick fail", e);
+                    }
+                }
+            }
+            // Shared particle renderers
+            for (Map<UUID, ParticleRenderer> map : sharedParticleRenderers.values()) {
+                for (ParticleRenderer renderer : map.values()) {
+                    try {
+                        renderer.tick();
+                    } catch (Exception e) {
+                        plugin.getLogger().log(Level.WARNING, "particle shared tick fail", e);
+                    }
+                }
+            }
+        }, interval, interval); // initial delay, repeat interval
     }
 
     public RegionRenderer getRenderer(UUID playerId) {
@@ -836,6 +1263,10 @@ public class RenderManager {
         if (rebaseTask != null) {
             rebaseTask.cancel();
             rebaseTask = null;
+        }
+        if (particleTickTask != null) {
+            particleTickTask.cancel();
+            particleTickTask = null;
         }
         clearAllRenders();
     }

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleCuboidRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleCuboidRenderer.java
@@ -1,0 +1,94 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.BoundingBox;
+import dev.twme.worldeditdisplay.region.CuboidRegion;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Particle-based renderer for CuboidRegion.
+ * <p>
+ * Renders:
+ * <ul>
+ *   <li>12 box edges as FLAME particles (interpolated with edge density)</li>
+ *   <li>Point1 / Point2 markers as REDSTONE DustOptions particles</li>
+ * </ul>
+ * No grid or fill faces are rendered.
+ */
+public class ParticleCuboidRenderer extends ParticleRenderer<CuboidRegion> {
+
+    public ParticleCuboidRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        super(plugin, player, settings);
+    }
+
+    @Override
+    public Class<CuboidRegion> getRegionType() {
+        return CuboidRegion.class;
+    }
+
+    @Override
+    public void render(CuboidRegion region) {
+        clear();
+
+        Vector3 point1 = region.getPoint1();
+        Vector3 point2 = region.getPoint2();
+
+        if (point1 == null && point2 == null) return;
+
+        // ── Point markers (1×1×1 box frames with DUST, matching TextDisplay style) ───
+        if (point1 != null) {
+            renderPointMarkerBox(point1, settings.getCuboidPoint1Color());
+        }
+        if (point2 != null) {
+            renderPointMarkerBox(point2, settings.getCuboidPoint2Color());
+        }
+
+        if (!region.isDefined()) return;
+
+        BoundingBox regionBox = region.getBoundingBox();
+        if (regionBox == null) return;
+
+        Vector3 min = regionBox.getMin();
+        Vector3 max = regionBox.getMax();
+
+        // Match CuboidRenderer's offset: max coordinates + 1 to encompass full blocks
+        double minX = min.getX();
+        double minY = min.getY();
+        double minZ = min.getZ();
+        double maxX = max.getX() + 1.0;
+        double maxY = max.getY() + 1.0;
+        double maxZ = max.getZ() + 1.0;
+
+        // ── 8 corners ────────────────────────────────────────────────────
+        Vector3 v000 = Vector3.at(minX, minY, minZ);
+        Vector3 v001 = Vector3.at(minX, minY, maxZ);
+        Vector3 v010 = Vector3.at(minX, maxY, minZ);
+        Vector3 v011 = Vector3.at(minX, maxY, maxZ);
+        Vector3 v100 = Vector3.at(maxX, minY, minZ);
+        Vector3 v101 = Vector3.at(maxX, minY, maxZ);
+        Vector3 v110 = Vector3.at(maxX, maxY, minZ);
+        Vector3 v111 = Vector3.at(maxX, maxY, maxZ);
+
+        // ── 12 edges (interpolated) ──────────────────────────────────────
+        // Bottom face
+        edgePoints.addAll(interpolateLine(v000, v001, edgeDensity));
+        edgePoints.addAll(interpolateLine(v000, v100, edgeDensity));
+        edgePoints.addAll(interpolateLine(v001, v101, edgeDensity));
+        edgePoints.addAll(interpolateLine(v100, v101, edgeDensity));
+
+        // Top face
+        edgePoints.addAll(interpolateLine(v010, v011, edgeDensity));
+        edgePoints.addAll(interpolateLine(v010, v110, edgeDensity));
+        edgePoints.addAll(interpolateLine(v011, v111, edgeDensity));
+        edgePoints.addAll(interpolateLine(v110, v111, edgeDensity));
+
+        // Vertical edges
+        edgePoints.addAll(interpolateLine(v000, v010, edgeDensity));
+        edgePoints.addAll(interpolateLine(v001, v011, edgeDensity));
+        edgePoints.addAll(interpolateLine(v100, v110, edgeDensity));
+        edgePoints.addAll(interpolateLine(v101, v111, edgeDensity));
+    }
+}

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleCylinderRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleCylinderRenderer.java
@@ -1,0 +1,96 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.CylinderRegion;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Particle-based renderer for CylinderRegion.
+ * <p>
+ * Renders:
+ * <ul>
+ *   <li>Upper ring and lower ring (circle particles with edge density)</li>
+ *   <li>8 vertical lines connecting the rings at 0/45/90/135/180/225/270/315 degrees</li>
+ *   <li>Center marker point as DUST</li>
+ * </ul>
+ */
+public class ParticleCylinderRenderer extends ParticleRenderer<CylinderRegion> {
+
+    public ParticleCylinderRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        super(plugin, player, settings);
+    }
+
+    @Override
+    public Class<CylinderRegion> getRegionType() {
+        return CylinderRegion.class;
+    }
+
+    @Override
+    public void render(CylinderRegion region) {
+        clear();
+
+        Vector3 center = region.getCenter();
+        if (center == null) return;
+
+        double radiusX = region.getRadiusX();
+        double radiusZ = region.getRadiusZ();
+        int minY = region.getMinY();
+        int maxY = region.getMaxY();
+
+        double cx = center.getX() + 0.5;
+        double cz = center.getZ() + 0.5;
+        // Extend radii by +0.5 so the ring passes through the outer face of outermost blocks
+        double ringRadiusX = radiusX + 0.5;
+        double ringRadiusZ = radiusZ + 0.5;
+        // Extend maxY by +1 to fully encompass the last block (same as CuboidRenderer)
+        double topY = maxY + 1.0;
+
+        // If both radii are zero, just show the center point as a marker box
+        if (radiusX <= 0 || radiusZ <= 0) {
+            renderPointMarkerBox(Vector3.at(cx, (minY + topY) / 2.0, cz), settings.getCylinderCenterColor());
+            return;
+        }
+
+        // ── Upper, middle, and lower rings ─────────────────────────────────
+        double midY = (minY + topY) / 2.0;
+        java.util.List<Vector3> upperRing = computeRingPoints(cx, 0, cz, ringRadiusX, ringRadiusZ, topY);
+        java.util.List<Vector3> middleRing = computeRingPoints(cx, 0, cz, ringRadiusX, ringRadiusZ, midY);
+        java.util.List<Vector3> lowerRing = computeRingPoints(cx, 0, cz, ringRadiusX, ringRadiusZ, minY);
+
+        edgePoints.addAll(upperRing);
+        edgePoints.addAll(middleRing);
+        edgePoints.addAll(lowerRing);
+
+        // ── 8 vertical lines connecting rings + top/bottom lid 米字 spokes ──
+        Vector3 centerTop = new Vector3(cx, topY, cz);
+        Vector3 centerBottom = new Vector3(cx, minY, cz);
+
+        int[] angleIndices = new int[8];
+        int segments = upperRing.size();
+        for (int i = 0; i < 8; i++) {
+            angleIndices[i] = (int) Math.round((double) i / 8.0 * segments) % segments;
+        }
+
+        for (int idx : angleIndices) {
+            Vector3 top = upperRing.get(idx);
+            Vector3 bottom = lowerRing.get(idx);
+
+            // Side vertical line (connecting top ring ↔ bottom ring)
+            edgePoints.addAll(interpolateLine(bottom, top, edgeDensity));
+
+            // Top lid spoke (center → ring)
+            edgePoints.addAll(interpolateLine(centerTop, top, edgeDensity));
+
+            // Bottom lid spoke (center → ring)
+            edgePoints.addAll(interpolateLine(centerBottom, bottom, edgeDensity));
+        }
+
+        // ── Center marker (1×1×1 box matching TextDisplay CylinderRenderer's renderCube with size 1.03) ──
+        renderPointMarkerBox(
+                Vector3.at(cx, (minY + topY) / 2.0, cz),
+                settings.getCylinderCenterColor());
+    }
+}

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleEllipsoidRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleEllipsoidRenderer.java
@@ -1,0 +1,94 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.EllipsoidRegion;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Particle-based renderer for EllipsoidRegion (spheres and ovals).
+ * <p>
+ * Uses a 5-great-circle (armillary sphere) strategy:
+ * <ul>
+ *   <li>1 horizontal XZ ring (equator)</li>
+ *   <li>4 vertical rings around Y axis at 0°, 45°, 90°, 135°</li>
+ * </ul>
+ * From above this forms a 米-shape pattern with a circle.
+ * Each ring uses the edge particle (FLAME) with density-based segment count.
+ */
+public class ParticleEllipsoidRenderer extends ParticleRenderer<EllipsoidRegion> {
+
+    public ParticleEllipsoidRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        super(plugin, player, settings);
+    }
+
+    @Override
+    public Class<EllipsoidRegion> getRegionType() {
+        return EllipsoidRegion.class;
+    }
+
+    @Override
+    public void render(EllipsoidRegion region) {
+        clear();
+
+        Vector3 center = region.getCenter();
+        Vector3 radii = region.getRadii();
+
+        if (center == null || radii == null) return;
+
+        double cx = center.getX();
+        double cy = center.getY();
+        double cz = center.getZ();
+        // Use block-centre coordinates (matching TextDisplay EllipsoidRenderer's centrePos)
+        double centreX = cx + 0.5;
+        double centreY = cy + 0.5;
+        double centreZ = cz + 0.5;
+        // Use raw radii from the region (TextDisplay does NOT add any offset to radii)
+        double rx = radii.getX();
+        double ry = radii.getY();
+        double rz = radii.getZ();
+
+        // Compute segment count from average radius
+        double avgRadius = (rx + ry + rz) / 3.0;
+        int segments = (int) Math.max(MIN_SEGMENTS,
+                Math.min(Math.ceil(Math.PI * avgRadius * edgeDensity), MAX_SEGMENTS));
+
+        // ── 1. Horizontal ring (XZ plane at centre Y) ─────────────────────
+        for (int i = 0; i < segments; i++) {
+            double angle = 2.0 * Math.PI * i / segments;
+            double x = centreX + rx * Math.cos(angle);
+            double z = centreZ + rz * Math.sin(angle);
+            edgePoints.add(new Vector3(x, centreY, z));
+        }
+
+        // ── 4 Vertical rings (rotated around Y axis) ───────────────────────
+        double[] ringAngles = {0.0, Math.PI / 4, Math.PI / 2, 3 * Math.PI / 4};
+
+        for (double theta : ringAngles) {
+            double cosT = Math.cos(theta);
+            double sinT = Math.sin(theta);
+
+            for (int i = 0; i < segments; i++) {
+                double alpha = 2.0 * Math.PI * i / segments;
+                double cosA = Math.cos(alpha);
+                double sinA = Math.sin(alpha);
+
+                double x = centreX + rx * cosA * cosT;
+                double y = centreY + ry * sinA;
+                double z = centreZ + rz * cosA * sinT;
+
+                edgePoints.add(new Vector3(x, y, z));
+            }
+        }
+
+        // ── Center marker (1×1×1 box at the block-min corner, matching TextDisplay EllipsoidRenderer) ──
+        // TextDisplay: renderCube(centerPos=(cx+0.5, cy+0.5, cz+0.5), size=1.0)
+        //   → box from (cx, cy, cz) to (cx+1, cy+1, cz+1)
+        // Particle: point = block-min corner = (cx, cy, cz)
+        //   → renderPointMarkerBox draws from (cx-0.03, cy-0.03, cz-0.03) to (cx+1.03, cy+1.03, cz+1.03) ✅
+        renderPointMarkerBox(new Vector3(cx, cy, cz),
+                settings.getEllipsoidCenterColor());
+    }
+}

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticlePolygonRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticlePolygonRenderer.java
@@ -1,0 +1,93 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import java.util.List;
+
+import org.bukkit.Color;
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.PolygonRegion;
+import dev.twme.worldeditdisplay.region.Vector2;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Particle-based renderer for PolygonRegion.
+ * <p>
+ * Renders:
+ * <ul>
+ *   <li>2D polygon boundary at minY (bottom ring)</li>
+ *   <li>2D polygon boundary at maxY (top ring)</li>
+ *   <li>Vertical lines connecting corresponding vertices</li>
+ * </ul>
+ */
+public class ParticlePolygonRenderer extends ParticleRenderer<PolygonRegion> {
+
+    public ParticlePolygonRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        super(plugin, player, settings);
+    }
+
+    @Override
+    public Class<PolygonRegion> getRegionType() {
+        return PolygonRegion.class;
+    }
+
+    @Override
+    public void render(PolygonRegion region) {
+        clear();
+
+        List<Vector2> points2d = region.getPoints();
+        if (points2d.isEmpty()) return;
+
+        int minY = region.getMinY();
+        // Extend maxY by +1 to fully encompass the last block (same as CuboidRenderer)
+        int topY = region.getMaxY() + 1;
+
+        // Convert 2D points to 3D at bottom and top Y levels
+        int n = points2d.size();
+
+        // ── Build bottom and top edge rings (x+0.5/z+0.5 = block centre, matching TextDisplay) ──
+        for (int i = 0; i < n; i++) {
+            Vector2 p = points2d.get(i);
+            if (p == null) continue;
+
+            Vector2 next = points2d.get((i + 1) % n);
+            if (next == null) continue;
+
+            double cx = 0.5, cz = 0.5;
+
+            // Bottom edge segment (block centre at minY)
+            Vector3 bottomFrom = new Vector3(p.getX() + cx, minY, p.getZ() + cz);
+            Vector3 bottomTo = new Vector3(next.getX() + cx, minY, next.getZ() + cz);
+            edgePoints.addAll(interpolateLine(bottomFrom, bottomTo, edgeDensity));
+
+            // Top edge segment (block centre at topY = maxY + 1)
+            Vector3 topFrom = new Vector3(p.getX() + cx, topY, p.getZ() + cz);
+            Vector3 topTo = new Vector3(next.getX() + cx, topY, next.getZ() + cz);
+            edgePoints.addAll(interpolateLine(topFrom, topTo, edgeDensity));
+        }
+
+        // ── Vertical lines at each vertex centre (x+0.5/z+0.5, matching TextDisplay) ──
+        for (int i = 0; i < n; i++) {
+            Vector2 p = points2d.get(i);
+            if (p == null) continue;
+
+            double cx = 0.5, cz = 0.5;
+            Vector3 bottom = new Vector3(p.getX() + cx, minY, p.getZ() + cz);
+            Vector3 top = new Vector3(p.getX() + cx, topY, p.getZ() + cz);
+            edgePoints.addAll(interpolateLine(bottom, top, edgeDensity));
+        }
+
+        // ── Vertex markers: full-height column at each vertex (matching TextDisplay PolygonRenderer.renderVertexMarkers) ──
+        Color vertexColor = settings.getPolygonVertexColor();
+        for (int i = 0; i < n; i++) {
+            Vector2 p = points2d.get(i);
+            if (p == null) continue;
+            // Full-height column from block-min corner to block-max corner
+            renderBoxFrame(
+                    new Vector3(p.getX(), minY, p.getZ()),
+                    new Vector3(p.getX() + 1.0, topY, p.getZ() + 1.0),
+                    vertexColor);
+        }
+    }
+}

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticlePolyhedronRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticlePolyhedronRenderer.java
@@ -1,0 +1,84 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.Color;
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.PolyhedronRegion;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Particle-based renderer for PolyhedronRegion.
+ * <p>
+ * Renders the edges of all triangular faces.
+ * Shared edges between adjacent faces are de-duplicated to avoid
+ * overlapping particle points.
+ */
+public class ParticlePolyhedronRenderer extends ParticleRenderer<PolyhedronRegion> {
+
+    public ParticlePolyhedronRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        super(plugin, player, settings);
+    }
+
+    @Override
+    public Class<PolyhedronRegion> getRegionType() {
+        return PolyhedronRegion.class;
+    }
+
+    @Override
+    public void render(PolyhedronRegion region) {
+        clear();
+
+        List<Vector3> vertices = region.getVertices();
+        List<int[]> faces = region.getFaces();
+
+        if (vertices.isEmpty() || faces.isEmpty()) return;
+
+        // De-duplicate edges using a set of ordered pairs (smaller index, larger index)
+        Set<String> edgeSet = new HashSet<>();
+
+        for (int[] face : faces) {
+            if (face == null || face.length < 3) continue;
+
+            for (int i = 0; i < face.length; i++) {
+                int a = face[i];
+                int b = face[(i + 1) % face.length];
+
+                if (a < 0 || a >= vertices.size() || b < 0 || b >= vertices.size()) continue;
+                if (vertices.get(a) == null || vertices.get(b) == null) continue;
+
+                // Normalise edge key: smaller index first
+                int min = Math.min(a, b);
+                int max = Math.max(a, b);
+                String key = min + ":" + max;
+
+                if (edgeSet.add(key)) {
+                    // New edge – interpolate with +0.5 offset on both endpoints
+                    // so the edge passes through the centre of the outermost blocks
+                    // (matching TextDisplay PolyhedronRenderer's convention).
+                    Vector3 vA = vertices.get(min);
+                    Vector3 vB = vertices.get(max);
+                    Vector3 offsetA = new Vector3(vA.getX() + 0.5, vA.getY() + 0.5, vA.getZ() + 0.5);
+                    Vector3 offsetB = new Vector3(vB.getX() + 0.5, vB.getY() + 0.5, vB.getZ() + 0.5);
+                    edgePoints.addAll(interpolateLine(offsetA, offsetB, edgeDensity));
+                }
+            }
+        }
+
+        // ── Vertex markers (small cubes matching TextDisplay PolyhedronRenderer.renderVertices) ──
+        Color vertexColor = settings.getPolyhedronVertexColor();
+        double vertexSize = settings.getPolyhedronVertexSize();
+        for (int i = 0; i < vertices.size(); i++) {
+            Vector3 v = vertices.get(i);
+            if (v == null) continue;
+            Color color = (i == 0) ? settings.getPolyhedronVertex0Color() : vertexColor;
+            Vector3 markerPos = new Vector3(v.getX() + 0.5, v.getY() + 0.5, v.getZ() + 0.5);
+            renderSmallCube(markerPos, color, vertexSize);
+        }
+    }
+}

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleRenderer.java
@@ -1,0 +1,434 @@
+package dev.twme.worldeditdisplay.display.particle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+
+import dev.twme.worldeditdisplay.WorldEditDisplay;
+import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
+import dev.twme.worldeditdisplay.region.Region;
+import dev.twme.worldeditdisplay.region.Vector3;
+
+/**
+ * Abstract base class for rendering region selections using Bukkit Particle API.
+ * <p>
+ * Designed for players whose client version is below 1.19.4 (no TextDisplay support).
+ * Uses {@link Player#spawnParticle(Particle, Location, int, double, double, double, double)}
+ * so that particles are sent to exactly one viewer, preserving per-player visibility.
+ * <p>
+ * Subclasses implement {@link #render(Region)} to discretise the region geometry
+ * into point clouds, and {@link #tick()} sends them to the owning player (or to
+ * shared viewers).
+ *
+ * @param <T> the region type this renderer handles
+ */
+public abstract class ParticleRenderer<T extends Region> {
+
+    protected final WorldEditDisplay plugin;
+    protected final Player player;
+    protected final UUID playerUUID;
+    protected final PlayerRenderSettings settings;
+
+    // Edge points → sent as FLAME particles (or DUST in shared mode)
+    protected List<Vector3> edgePoints;
+    // Colored edge points → sent as DUST with their specific colour (for point markers rendered as box frames)
+    protected List<ColoredEdgePoint> coloredEdgePoints;
+    // Marker points (point1/point2) → single DUST dot (simple fallback)
+    protected List<MarkerPoint> markerPoints;
+    // Viewers that should receive particles (only the owner by default)
+    protected final List<UUID> viewers;
+
+    // When non-null, ALL particles use this colour (shared selections via DUST).
+    // When null, edge points use FLAME and marker points use the configured DustOptions color.
+    protected Color sharedColor;
+
+    // Per-frame cache to avoid recreating lists on every tick
+    private boolean pointsDirty = true;
+
+    // Configuration (will be loaded from ParticleFallbackSettings in Phase 3)
+    protected double edgeDensity = 1.0;
+    protected int particleInterval = 5; // ticks between particle sends
+
+    protected static final double MIN_SEGMENTS = 12;
+    protected static final double MAX_SEGMENTS = 60;
+
+    protected ParticleRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
+        this.plugin = plugin;
+        this.player = player;
+        this.playerUUID = player.getUniqueId();
+        this.settings = settings;
+        this.edgePoints = new ArrayList<>();
+        this.coloredEdgePoints = new ArrayList<>();
+        this.markerPoints = new ArrayList<>();
+        this.viewers = new ArrayList<>();
+        this.viewers.add(playerUUID);
+    }
+
+    // ─── Abstract methods ────────────────────────────────────────────────────
+
+    /**
+     * Compute the point cloud for this region.
+     * Subclasses must populate {@link #edgePoints} and {@link #markerPoints}.
+     */
+    public abstract void render(T region);
+
+    /**
+     * @return the concrete region type this renderer handles
+     */
+    public abstract Class<T> getRegionType();
+
+    // ─── Tick / send ─────────────────────────────────────────────────────────
+
+    /**
+     * Send all cached points as particles to every viewer.
+     * Call this periodically (e.g. every 5 ticks) via a shared scheduler task.
+     */
+    public void tick() {
+        if (edgePoints.isEmpty() && coloredEdgePoints.isEmpty() && markerPoints.isEmpty()) return;
+        if (viewers.isEmpty()) return;
+
+        if (sharedColor != null) {
+            Particle.DustOptions dustOptions = new Particle.DustOptions(
+                    Color.fromRGB(sharedColor.getRed(), sharedColor.getGreen(), sharedColor.getBlue()),
+                    1.0f);
+            for (UUID viewerId : viewers) {
+                Player viewer = Bukkit.getPlayer(viewerId);
+                if (viewer == null || !viewer.isOnline()) continue;
+                sendPointsAsDust(viewer, dustOptions);
+            }
+        } else {
+            for (UUID viewerId : viewers) {
+                Player viewer = Bukkit.getPlayer(viewerId);
+                if (viewer == null || !viewer.isOnline()) continue;
+                sendFlameParticles(viewer);
+                sendColoredEdgeParticles(viewer);
+                sendMarkerParticles(viewer);
+            }
+        }
+    }
+
+    private void sendFlameParticles(Player viewer) {
+        for (Vector3 point : edgePoints) {
+            viewer.spawnParticle(Particle.FLAME,
+                    point.getX(), point.getY(), point.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0);
+        }
+    }
+
+    /** All point types rendered as DUST with the same colour (shared / viewall mode). */
+    private void sendPointsAsDust(Player viewer, Particle.DustOptions dustOptions) {
+        for (Vector3 point : edgePoints) {
+            viewer.spawnParticle(Particle.DUST,
+                    point.getX(), point.getY(), point.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+        for (ColoredEdgePoint cp : coloredEdgePoints) {
+            viewer.spawnParticle(Particle.DUST,
+                    cp.position.getX(), cp.position.getY(), cp.position.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+        for (MarkerPoint mp : markerPoints) {
+            viewer.spawnParticle(Particle.DUST,
+                    mp.position.getX(), mp.position.getY(), mp.position.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+    }
+
+    /** Colored edge points (point-marker box frames) → DUST with their own colour. */
+    private void sendColoredEdgeParticles(Player viewer) {
+        for (ColoredEdgePoint cp : coloredEdgePoints) {
+            Color color = cp.color;
+            if (color == null) color = Color.RED;
+            Particle.DustOptions dustOptions = new Particle.DustOptions(
+                    Color.fromRGB(color.getRed(), color.getGreen(), color.getBlue()),
+                    1.0f);
+            viewer.spawnParticle(Particle.DUST,
+                    cp.position.getX(), cp.position.getY(), cp.position.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+    }
+
+    /** Single-point markers → DUST with their own colour. */
+    private void sendMarkerParticles(Player viewer) {
+        for (MarkerPoint mp : markerPoints) {
+            Color color = mp.color;
+            if (color == null) color = Color.RED;
+            Particle.DustOptions dustOptions = new Particle.DustOptions(
+                    Color.fromRGB(color.getRed(), color.getGreen(), color.getBlue()),
+                    1.0f);
+            viewer.spawnParticle(Particle.DUST,
+                    mp.position.getX(), mp.position.getY(), mp.position.getZ(),
+                    0, 0.0, 0.0, 0.0, 0.0, dustOptions);
+        }
+    }
+
+    // ─── Cleanup ─────────────────────────────────────────────────────────────
+
+    /**
+     * Clear all cached points and reset state.
+     */
+    public void clear() {
+        edgePoints.clear();
+        coloredEdgePoints.clear();
+        markerPoints.clear();
+        pointsDirty = true;
+    }
+
+    /**
+     * Mark points as needing recomputation on the next tick.
+     */
+    protected void markDirty() {
+        pointsDirty = true;
+    }
+
+    // ─── Viewer management ───────────────────────────────────────────────────
+
+    public void addViewer(UUID viewerId) {
+        if (!viewers.contains(viewerId)) {
+            viewers.add(viewerId);
+        }
+    }
+
+    public void removeViewer(UUID viewerId) {
+        viewers.remove(viewerId);
+    }
+
+    public List<UUID> getViewers() {
+        return viewers;
+    }
+
+    // ─── Shared colour ───────────────────────────────────────────────────────
+
+    /**
+     * When set, all particles (edges + markers) use REDSTONE with DUST colour.
+     * Used for share / viewall modes so each sharer can be distinguished by colour.
+     */
+    public void setSharedColor(Color color) {
+        this.sharedColor = color;
+    }
+
+    public Color getSharedColor() {
+        return sharedColor;
+    }
+
+    // ─── Configuration ───────────────────────────────────────────────────────
+
+    /**
+     * Apply global particle fallback settings from the server config.
+     * Called once after the renderer is created.
+     */
+    public void applyServerSettings(dev.twme.worldeditdisplay.config.RenderSettings renderSettings) {
+        this.edgeDensity = Math.max(0.25, Math.min(renderSettings.getParticleEdgeDensity(), 4.0));
+    }
+
+    public void setEdgeDensity(double edgeDensity) {
+        this.edgeDensity = Math.max(0.25, Math.min(edgeDensity, 4.0));
+    }
+
+    public void setParticleInterval(int intervalTicks) {
+        this.particleInterval = Math.max(1, intervalTicks);
+    }
+
+    public double getEdgeDensity() {
+        return edgeDensity;
+    }
+
+    // ─── Helper: compute circle ring points (for cylinder, ellipsoid) ────────
+
+    /**
+     * Compute points along a circle/ellipse ring.
+     *
+     * @param centerX  centre X
+     * @param centerY  centre Y
+     * @param centerZ  centre Z
+     * @param radiusX  radius along X axis
+     * @param radiusZ  radius along Z axis
+     * @param yOffset  offset to add to Y (for vertical positioning)
+     * @return list of points around the ring
+     */
+    protected List<Vector3> computeRingPoints(double centerX, double centerY, double centerZ,
+                                               double radiusX, double radiusZ, double yOffset) {
+        double avgRadius = (radiusX + radiusZ) / 2.0;
+        int segments = (int) Math.max(MIN_SEGMENTS,
+                Math.min(Math.ceil(Math.PI * avgRadius * edgeDensity), MAX_SEGMENTS));
+
+        List<Vector3> points = new ArrayList<>(segments);
+        for (int i = 0; i < segments; i++) {
+            double angle = 2.0 * Math.PI * i / segments;
+            double dx = radiusX * Math.cos(angle);
+            double dz = radiusZ * Math.sin(angle);
+            points.add(new Vector3(centerX + dx, centerY + yOffset, centerZ + dz));
+        }
+        return points;
+    }
+
+    // ─── Helper: interpolate between two points ──────────────────────────────
+
+    /**
+     * Linearly interpolate between two 3D points with the given density.
+     * Includes both endpoints so the entire edge is covered.
+     *
+     * @return list of points along the line segment, inclusive of both {@code from} and {@code to}
+     */
+    protected List<Vector3> interpolateLine(Vector3 from, Vector3 to, double density) {
+        double distance = from.distance(to);
+        if (distance < 0.001) {
+            List<Vector3> result = new ArrayList<>(1);
+            result.add(from);
+            return result;
+        }
+        // Number of segments = ceil(distance * density); number of points = segments + 1
+        int segments = Math.max(1, (int) Math.ceil(distance * density));
+        List<Vector3> points = new ArrayList<>(segments + 1);
+        for (int i = 0; i <= segments; i++) {
+            double t = (double) i / segments;
+            double x = from.getX() + (to.getX() - from.getX()) * t;
+            double y = from.getY() + (to.getY() - from.getY()) * t;
+            double z = from.getZ() + (to.getZ() - from.getZ()) * t;
+            points.add(new Vector3(x, y, z));
+        }
+        return points;
+    }
+
+    // ─── Helper data classes ────────────────────────────────────────────────
+
+    /**
+     * An edge point with an associated colour, rendered as DUST.
+     * Used for point-marker box frames (1×1×1 block outlines).
+     */
+    protected static class ColoredEdgePoint {
+        final Vector3 position;
+        final Color color;
+
+        ColoredEdgePoint(Vector3 position, Color color) {
+            this.position = position;
+            this.color = color;
+        }
+    }
+
+    /**
+     * A single-dot marker point with an associated colour, rendered as DUST.
+     */
+    protected static class MarkerPoint {
+        final Vector3 position;
+        final Color color;
+
+        MarkerPoint(Vector3 position, Color color) {
+            this.position = position;
+            this.color = color;
+        }
+    }
+
+    // ─── Helper: render a box frame between two corners ─────────────────────
+
+    /**
+     * Renders the 12 edges of an axis-aligned box from {@code min} to {@code max}
+     * as coloured edge points (DUST). Matches TextDisplay's {@code renderBoxFrame}.
+     */
+    protected void renderBoxFrame(Vector3 min, Vector3 max, Color color) {
+        double minX = min.getX(), minY = min.getY(), minZ = min.getZ();
+        double maxX = max.getX(), maxY = max.getY(), maxZ = max.getZ();
+
+        Vector3 v000 = new Vector3(minX, minY, minZ);
+        Vector3 v001 = new Vector3(minX, minY, maxZ);
+        Vector3 v010 = new Vector3(minX, maxY, minZ);
+        Vector3 v011 = new Vector3(minX, maxY, maxZ);
+        Vector3 v100 = new Vector3(maxX, minY, minZ);
+        Vector3 v101 = new Vector3(maxX, minY, maxZ);
+        Vector3 v110 = new Vector3(maxX, maxY, minZ);
+        Vector3 v111 = new Vector3(maxX, maxY, maxZ);
+
+        double density = Math.max(edgeDensity, 3.0);
+        for (Vector3 v : interpolateLine(v000, v001, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v000, v100, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v001, v101, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v100, v101, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v010, v011, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v010, v110, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v011, v111, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v110, v111, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v000, v010, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v001, v011, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v100, v110, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+        for (Vector3 v : interpolateLine(v101, v111, density)) coloredEdgePoints.add(new ColoredEdgePoint(v, color));
+    }
+
+    // ─── Helper: render a point marker as a 1×1×1 box frame ─────────────────
+
+    /**
+     * Adds coloured edge points forming a 1×1×1 box around the given block coordinate,
+     * matching the visual style of {@code CuboidRenderer.renderPointMarker()}.
+     * The box spans from {@code (x-0.03, y-0.03, z-0.03)} to {@code (x+1.03, y+1.03, z+1.03)}.
+     */
+    protected void renderPointMarkerBox(Vector3 point, Color color) {
+        if (color == null) color = Color.RED;
+        double padding = 0.03;
+        double minX = point.getX() - padding;
+        double minY = point.getY() - padding;
+        double minZ = point.getZ() - padding;
+        double maxX = point.getX() + 1.0 + padding;
+        double maxY = point.getY() + 1.0 + padding;
+        double maxZ = point.getZ() + 1.0 + padding;
+        renderBoxFrame(new Vector3(minX, minY, minZ), new Vector3(maxX, maxY, maxZ), color);
+    }
+
+    // ─── Helper: render a small cube marker ─────────────────────────────────
+
+    /**
+     * Renders a small cube centred at {@code center} with the given {@code size}.
+     * Used for Polyhedron and Cylinder centre markers (matching TextDisplay's
+     * {@code renderCube}), which are small — not full 1×1×1 blocks.
+     */
+    protected void renderSmallCube(Vector3 center, Color color, double size) {
+        if (color == null) color = Color.RED;
+        double half = Math.max(size, 0.02) / 2.0;
+        renderBoxFrame(
+                new Vector3(center.getX() - half, center.getY() - half, center.getZ() - half),
+                new Vector3(center.getX() + half, center.getY() + half, center.getZ() + half),
+                color);
+    }
+
+    // ─── Post-render processing ──────────────────────────────────────────────
+
+    private static final int LARGE_SELECTION_THRESHOLD = 800;
+    private static final double MIN_DOWNGRADE_SCALE = 0.25;
+
+    /**
+     * Called automatically by RenderManager after {@link #render(Region)}.
+     * If the total particle count exceeds the threshold, edge points are
+     * sub-sampled to keep packet count manageable.
+     */
+    public void postRender() {
+        int total = edgePoints.size() + coloredEdgePoints.size() + markerPoints.size();
+        if (total <= LARGE_SELECTION_THRESHOLD) return;
+
+        double scale = Math.max(MIN_DOWNGRADE_SCALE, (double) LARGE_SELECTION_THRESHOLD / total);
+        int targetEdge = Math.max(8, (int) (edgePoints.size() * scale));
+
+        if (targetEdge < edgePoints.size()) {
+            List<Vector3> reduced = new ArrayList<>(targetEdge);
+            int step = Math.max(1, edgePoints.size() / targetEdge);
+            for (int i = 0; i < edgePoints.size(); i += step) {
+                reduced.add(edgePoints.get(i));
+            }
+            edgePoints = reduced;
+        }
+    }
+
+    // ─── Point count ─────────────────────────────────────────────────────────
+
+    /**
+     * @return the total number of edge + marker points currently in the cache
+     */
+    public int getPointCount() {
+        return edgePoints.size() + coloredEdgePoints.size() + markerPoints.size();
+    }
+
+    // ─── Viewers ────────────────────────────────────────────────────────────
+}

--- a/src/main/java/dev/twme/worldeditdisplay/listener/OutboundPacketListener.java
+++ b/src/main/java/dev/twme/worldeditdisplay/listener/OutboundPacketListener.java
@@ -40,10 +40,10 @@ public class OutboundPacketListener implements PacketListener {
 
         PlayerData playerData = PlayerData.getPlayerData(player);
 
-        // Do not send CUI messages to Bedrock (Floodgate) players
+        // Bedrock (Floodgate) players: cancel CUI packets (they don't support CUI)
+        // but still parse the message so we can create Region objects for particle rendering.
         if (playerData.isBedrockPlayer()) {
             event.setCancelled(true);
-            return;
         }
 
         // If debug mode, show the received WECUI message
@@ -51,7 +51,7 @@ public class OutboundPacketListener implements PacketListener {
             MessageUtil.sendTranslated(player, "command.wedisplay.debug.cui_message", message);
         }
 
-        // If CUI already enabled, let the packet go through
+        // If CUI already enabled, let the packet go through (unless bedrock, already cancelled)
         if (playerData.isCuiEnabled()) return;
 
         event.setCancelled(true); // cancel packet sending

--- a/src/main/java/dev/twme/worldeditdisplay/listener/PlayerJoinListener.java
+++ b/src/main/java/dev/twme/worldeditdisplay/listener/PlayerJoinListener.java
@@ -14,6 +14,7 @@ import dev.twme.worldeditdisplay.WorldEditDisplay;
 import dev.twme.worldeditdisplay.common.Constants;
 import dev.twme.worldeditdisplay.player.PlayerData;
 import dev.twme.worldeditdisplay.util.FloodgateUtil;
+import dev.twme.worldeditdisplay.util.VersionChecker;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 
 /**
@@ -42,6 +43,11 @@ public class PlayerJoinListener implements Listener {
         // Detect Floodgate Bedrock players and disable CUI for them
         if (FloodgateUtil.isBedrockPlayer(player)) {
             playerData.setBedrockPlayer(true);
+        }
+
+        // Detect client version: < 1.19.4 players use particle fallback (no TextDisplay support)
+        if (VersionChecker.isViaVersionAvailable()) {
+            playerData.setParticleFallback(VersionChecker.needsParticleFallback(player));
         }
 
         // Initialize viewall/label session defaults from permission nodes

--- a/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
+++ b/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
@@ -23,12 +23,28 @@ import io.github.retrooper.packetevents.util.folia.TaskWrapper;
 public class PlayerData {
     private static final Map<UUID, PlayerData> playerDataMap = new HashMap<>();
 
+    /**
+     * Render mode preference for the particle-fallback feature.
+     * <ul>
+     *   <li>{@link #AUTO} — uses ViaVersion client detection (< 1.19.4 → particles)</li>
+     *   <li>{@link #TEXT_DISPLAY} — always use TextDisplay entities</li>
+     *   <li>{@link #PARTICLE} — always use particle fallback</li>
+     * </ul>
+     */
+    public enum RenderMode {
+        AUTO,
+        TEXT_DISPLAY,
+        PARTICLE
+    }
+
     private final Player player;
     private final CUIEventDispatcher dispatcher;
     private boolean isCuiEnabled = false;
     private boolean renderingEnabled = false; // default off; will enable on login if player has permission
     private boolean debugEnabled = false;
     private boolean bedrockPlayer = false; // true if joined via Floodgate (GeyserMC)
+    private boolean particleFallback = false; // true if player's client is < 1.19.4 (TextDisplay unsupported)
+    private RenderMode renderMode = RenderMode.AUTO; // user preference, defaults to AUTO
 
     // Current single selection
     private Region currentRegion;
@@ -131,6 +147,52 @@ public class PlayerData {
      */
     public void setBedrockPlayer(boolean bedrockPlayer) {
         this.bedrockPlayer = bedrockPlayer;
+    }
+
+    /**
+     * Check if this player needs particle fallback (client < 1.19.4, no TextDisplay support).
+     * <p>
+     * Considers the player's {@link RenderMode} preference:
+     * <ul>
+     *   <li>{@link RenderMode#TEXT_DISPLAY} — always returns {@code false}</li>
+     *   <li>{@link RenderMode#PARTICLE} — always returns {@code true}</li>
+     *   <li>{@link RenderMode#AUTO} — returns the auto-detected value</li>
+     * </ul>
+     * <p>
+     * Bedrock (Floodgate) players are always forced to particle fallback
+     * since they do not support TextDisplay entities.
+     */
+    public boolean isParticleFallback() {
+        if (isBedrockPlayer()) return true;
+        return switch (renderMode) {
+            case TEXT_DISPLAY -> false;
+            case PARTICLE -> true;
+            case AUTO -> particleFallback;
+        };
+    }
+
+    /**
+     * Set the auto-detected fallback flag (called by PlayerJoinListener).
+     */
+    public void setParticleFallback(boolean particleFallback) {
+        this.particleFallback = particleFallback;
+    }
+
+    /**
+     * Get the current render mode preference.
+     */
+    public RenderMode getRenderMode() {
+        return renderMode;
+    }
+
+    /**
+     * Set the render mode preference.
+     *
+     * @param mode the desired mode ({@link RenderMode#AUTO}, {@link RenderMode#TEXT_DISPLAY},
+     *             or {@link RenderMode#PARTICLE})
+     */
+    public void setRenderMode(RenderMode mode) {
+        this.renderMode = mode != null ? mode : RenderMode.AUTO;
     }
 
     /**

--- a/src/main/java/dev/twme/worldeditdisplay/util/VersionChecker.java
+++ b/src/main/java/dev/twme/worldeditdisplay/util/VersionChecker.java
@@ -1,0 +1,66 @@
+package dev.twme.worldeditdisplay.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+
+/**
+ * Utility for checking player client version via ViaVersion API.
+ * ViaVersion is optional; if the plugin is not present or API is unavailable,
+ * all checks gracefully fall back to conservative assumptions.
+ */
+public final class VersionChecker {
+
+    private static final boolean VIAVERSION_AVAILABLE;
+
+    static {
+        boolean available = false;
+        try {
+            Class.forName("com.viaversion.viaversion.api.Via");
+            available = Bukkit.getPluginManager().getPlugin("ViaVersion") != null;
+        } catch (ClassNotFoundException ignored) {
+        }
+        VIAVERSION_AVAILABLE = available;
+    }
+
+    private VersionChecker() {
+        // utility class
+    }
+
+    /**
+     * Returns true if ViaVersion is present on the server.
+     */
+    public static boolean isViaVersionAvailable() {
+        return VIAVERSION_AVAILABLE;
+    }
+
+    /**
+     * Checks if the player's client supports TextDisplay entities (1.19.4+).
+     *
+     * @param player the player to check
+     * @return true if the player's client version is >= 1.19.4;
+     *         false if ViaVersion is not installed, API fails, or player is < 1.19.4.
+     */
+    public static boolean isTextDisplaySupported(Player player) {
+        if (!VIAVERSION_AVAILABLE || player == null) {
+            return false;
+        }
+        try {
+            ProtocolVersion version = Via.getAPI().getPlayerProtocolVersion(player);
+            return version.newerThanOrEqualTo(ProtocolVersion.v1_19_4);
+        } catch (Exception e) {
+            // API unavailable or player not tracked → conservative fallback
+            return false;
+        }
+    }
+
+    /**
+     * Inverse of {@link #isTextDisplaySupported(Player)}.
+     * Returns true if the player should use particle fallback rendering.
+     */
+    public static boolean needsParticleFallback(Player player) {
+        return !isTextDisplaySupported(player);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -199,3 +199,17 @@ renderer:
     vertex_size: 1.0                    # Vertex marker size
     vertex_thickness: 0.06              # Vertex marker cube thickness
 
+# Particle Fallback Settings (for clients < 1.19.4 that do not support TextDisplay entities)
+particle_fallback:
+  # Whether to enable particle fallback
+  enabled: true
+  # How often to re-send particles (in ticks, 20 ticks = 1 second)
+  update_interval: 20
+  # Maximum distance (blocks) for particles to be visible to a viewer
+  max_render_distance: 64
+  # Edge particle density (particles per block of edge length, range 0.25 – 4.0)
+  edge_density: 1.0
+  # Point marker colours (#RRGGBBAA format)
+  point1_color: "#33CC33CC"
+  point2_color: "#3333CCCC"
+

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -64,8 +64,17 @@ command:
       enabled: "<green>Debug mode enabled! Entity count will be shown on each render."
       disabled: "<#E8C96D>Debug mode disabled!"
       entity_count: "<#C2C7D3>[Debug] Current display entity count: <white>%d"
+      particle_count: "<#C2C7D3>[Debug] Current particle point count: <white>%d"
       cui_message: "<#C2C7D3>[Debug] Received WECUI message: <white>%s"
-    
+
+    render:
+      current: "<#C2C7D3>Current render mode: <white>%s"
+      set: "<green>Render mode set to: <white>%s"
+      usage: "<#CE5F4E>Usage: <#D1968C>/wedisplay render <auto|text|particle|toggle>"
+      mode_auto: "<#C2C7D3>Auto (detect from client version)"
+      mode_text: "<green>TextDisplay"
+      mode_particle: "<#E8C96D>Particle (fallback)"
+
     help:
       title: "<#478FC6>\u2014\u2014 <white>WorldEditDisplay Commands <#478FC6>\u2014\u2014"
       set: "<#478FC6>/wedisplay set <renderer> <setting> <value>"
@@ -81,11 +90,9 @@ command:
       toggle: "<#478FC6>/wedisplay toggle"
       toggle_desc: "<#C2C7D3>  \u21b3 Enable or disable the selection visualizer"
       debug: "<#478FC6>/wedisplay debug"
-      debug_desc: "<#C2C7D3>  \u21b3 Toggle debug overlay (shows live entity count per render)"
-      share: "<#478FC6>/wedisplay share [invite|accept|revoke|unwatch|list]"
-      share_desc: "<#C2C7D3>  \u21b3 Share your selection view with another online player"
-      view: "<#478FC6>/wedisplay view [hide|hideall|unhide|label|list]"
-      view_desc: "<#C2C7D3>  \u21b3 Observe all players' selections and manage visibility"
+      debug_desc: "<#C2C7D3>  \u21b3 Toggle debug overlay (shows live entity/particle count per render)"
+      render: "<#478FC6>/wedisplay render [auto|text|particle|toggle]"
+      render_desc: "<#C2C7D3>  \u21b3 Switch between TextDisplay and particle fallback rendering"
 
     share:
       player_not_found: "<#CE5F4E>Player '<white>%s<#CE5F4E>' not found or not online!"

--- a/src/main/resources/lang/zh_cn.yml
+++ b/src/main/resources/lang/zh_cn.yml
@@ -64,8 +64,17 @@ command:
       enabled: "<green>已开启调试模式！每次渲染时将显示实体数量。"
       disabled: "<#E8C96D>已关闭调试模式！"
       entity_count: "<#C2C7D3>[调试] 当前显示实体数量：<white>%d"
+      particle_count: "<#C2C7D3>[调试] 当前粒子点数量：<white>%d"
       cui_message: "<#C2C7D3>[调试] 收到 WECUI 消息：<white>%s"
-    
+
+    render:
+      current: "<#C2C7D3>当前渲染模式：<white>%s"
+      set: "<green>渲染模式已设为：<white>%s"
+      usage: "<#CE5F4E>用法：<#D1968C>/wedisplay render <auto|text|particle|toggle>"
+      mode_auto: "<#C2C7D3>自动（根据客户端版本检测）"
+      mode_text: "<green>TextDisplay"
+      mode_particle: "<#E8C96D>粒子（回退）"
+
     help:
       title: "<#478FC6>\u2014\u2014 <white>WorldEditDisplay 指令说明 <#478FC6>\u2014\u2014"
       set: "<#478FC6>/wedisplay set <renderer> <setting> <value>"
@@ -81,11 +90,9 @@ command:
       toggle: "<#478FC6>/wedisplay toggle"
       toggle_desc: "<#C2C7D3>  \u21b3 开启或关闭选区可视化显示"
       debug: "<#478FC6>/wedisplay debug"
-      debug_desc: "<#C2C7D3>  \u21b3 切换调试覆盖层（实时显示每次渲染的实体数量）"
-      share: "<#478FC6>/wedisplay share [invite|accept|revoke|unwatch|list]"
-      share_desc: "<#C2C7D3>  \u21b3 将你的选区视图共享给另一位在线玩家"
-      view: "<#478FC6>/wedisplay view [hide|hideall|unhide|label|list]"
-      view_desc: "<#C2C7D3>  \u21b3 观察所有玩家的选区并管理可见性（管理员工具）"
+      debug_desc: "<#C2C7D3>  \u21b3 切换调试覆盖层（实时显示每次渲染的实体/粒子数量）"
+      render: "<#478FC6>/wedisplay render [auto|text|particle|toggle]"
+      render_desc: "<#C2C7D3>  \u21b3 切换 TextDisplay 与粒子回退渲染模式"
 
     share:
       player_not_found: "<#CE5F4E>找不到玩家「<white>%s<#CE5F4E>」或玩家不在线！"

--- a/src/main/resources/lang/zh_tw.yml
+++ b/src/main/resources/lang/zh_tw.yml
@@ -64,8 +64,17 @@ command:
       enabled: "<green>已開啟除錯模式！每次渲染時將顯示實體數量。"
       disabled: "<#E8C96D>已關閉除錯模式！"
       entity_count: "<#C2C7D3>[除錯] 目前顯示實體數量：<white>%d"
+      particle_count: "<#C2C7D3>[除錯] 目前粒子點數量：<white>%d"
       cui_message: "<#C2C7D3>[除錯] 收到 WECUI 訊息：<white>%s"
-    
+
+    render:
+      current: "<#C2C7D3>目前渲染模式：<white>%s"
+      set: "<green>渲染模式已設為：<white>%s"
+      usage: "<#CE5F4E>用法：<#D1968C>/wedisplay render <auto|text|particle|toggle>"
+      mode_auto: "<#C2C7D3>自動（根據客戶端版本偵測）"
+      mode_text: "<green>TextDisplay"
+      mode_particle: "<#E8C96D>粒子（回退）"
+
     help:
       title: "<#478FC6>\u2014\u2014 <white>WorldEditDisplay 指令說明 <#478FC6>\u2014\u2014"
       set: "<#478FC6>/wedisplay set <renderer> <setting> <value>"
@@ -81,11 +90,9 @@ command:
       toggle: "<#478FC6>/wedisplay toggle"
       toggle_desc: "<#C2C7D3>  \u21b3 啟用或停用選區可視化顯示"
       debug: "<#478FC6>/wedisplay debug"
-      debug_desc: "<#C2C7D3>  \u21b3 切換除錯覆蓋層（即時顯示每次渲染的實體數量）"
-      share: "<#478FC6>/wedisplay share [invite|accept|revoke|unwatch|list]"
-      share_desc: "<#C2C7D3>  \u21b3 將你的選區視圖分享給另一位在線玩家"
-      view: "<#478FC6>/wedisplay view [hide|hideall|unhide|label|list]"
-      view_desc: "<#C2C7D3>  \u21b3 觀看所有玩家的選區並管理可見性（管理員工具）"
+      debug_desc: "<#C2C7D3>  \u21b3 切換除錯覆蓋層（即時顯示每次渲染的實體/粒子數量）"
+      render: "<#478FC6>/wedisplay render [auto|text|particle|toggle]"
+      render_desc: "<#C2C7D3>  \u21b3 切換 TextDisplay 與粒子回退渲染模式"
 
     share:
       player_not_found: "<#CE5F4E>找不到玩家「<white>%s<#CE5F4E>」或玩家不在線！"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,6 +23,7 @@ commands:
       /wedisplay show [renderer] - Show current settings
       /wedisplay reloadplayer - Reload personal settings
       /wedisplay toggle - Toggle rendering on/off
+      /wedisplay render [auto|text|particle|toggle] - Switch render mode
     aliases: [worldeditdisplay]
 
 permissions:
@@ -70,6 +71,9 @@ permissions:
     default: true
   worldeditdisplay.reload:
     description: Allow reloading WorldEditDisplay configuration
+    default: op
+  worldeditdisplay.use.render:
+    description: Allow using /wedisplay render to switch between TextDisplay and particle fallback rendering
     default: op
   worldeditdisplay.render.auto-enable:
     description: Automatically enable rendering when player joins server


### PR DESCRIPTION
Adds particle-based fallback rendering for clients that don't support TextDisplay (pre‑1.19.4 and Bedrock). The `/wedisplay render` command lets players choose between TextDisplay, particle, or automatic mode, with version detection via ViaVersion.