### PR TITLE
Enhance player quit handling and improve thread safety

### DIFF
--- a/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
+++ b/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
@@ -26,6 +26,7 @@ import dev.twme.worldeditdisplay.share.ShareManager;
 import dev.twme.worldeditdisplay.util.MessageUtil;
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
+import io.github.retrooper.packetevents.util.folia.TaskWrapper;
 import me.tofaa.entitylib.APIConfig;
 import me.tofaa.entitylib.EntityLib;
 import me.tofaa.entitylib.spigot.SpigotEntityLibPlatform;
@@ -38,6 +39,15 @@ public final class WorldEditDisplay extends JavaPlugin {
     private LanguageManager languageManager;
     private ShareManager shareManager;
     private final Set<UUID> viewAllPlayers = ConcurrentHashMap.newKeySet();
+
+    // Packet listener references (kept for clean unregistration on disable)
+    private com.github.retrooper.packetevents.event.PacketListenerCommon inboundPacketListener;
+    private com.github.retrooper.packetevents.event.PacketListenerCommon outboundPacketListener;
+
+    // Folia scheduled task references (cancelled on disable to prevent leaks)
+    private TaskWrapper shareSaveTask;
+    private TaskWrapper expiryPurgeTask;
+    private TaskWrapper playerSettingsSaveTask;
 
     @Override
     public void onLoad() {
@@ -56,8 +66,8 @@ public final class WorldEditDisplay extends JavaPlugin {
 
         PacketEvents.getAPI().init();
 
-        PacketEvents.getAPI().getEventManager().registerListener(new InboundPacketListener(), PacketListenerPriority.NORMAL);
-        PacketEvents.getAPI().getEventManager().registerListener(new OutboundPacketListener(), PacketListenerPriority.NORMAL);
+        inboundPacketListener = PacketEvents.getAPI().getEventManager().registerListener(new InboundPacketListener(), PacketListenerPriority.NORMAL);
+        outboundPacketListener = PacketEvents.getAPI().getEventManager().registerListener(new OutboundPacketListener(), PacketListenerPriority.NORMAL);
 
         SpigotEntityLibPlatform platform = new SpigotEntityLibPlatform(this);
         APIConfig settings = new APIConfig(PacketEvents.getAPI())
@@ -96,16 +106,16 @@ public final class WorldEditDisplay extends JavaPlugin {
 
         // Schedule periodic share save and expiry purge
         int saveIntervalMinutes = Math.max(1, getConfig().getInt("share.auto_save_interval", 5));
-        FoliaScheduler.getAsyncScheduler().runAtFixedRate(this, task -> {
+        shareSaveTask = FoliaScheduler.getAsyncScheduler().runAtFixedRate(this, task -> {
             if (shareManager != null) shareManager.save();
         }, saveIntervalMinutes, saveIntervalMinutes, TimeUnit.MINUTES);
         // Purge expired invites every 10 seconds
-        FoliaScheduler.getGlobalRegionScheduler().runAtFixedRate(this, task -> {
+        expiryPurgeTask = FoliaScheduler.getGlobalRegionScheduler().runAtFixedRate(this, task -> {
             if (shareManager != null) shareManager.purgeAllExpiredRequests();
         }, 200L, 200L);
 
         // Schedule periodic player settings save every 5 minutes
-        FoliaScheduler.getAsyncScheduler().runAtFixedRate(this, task -> {
+        playerSettingsSaveTask = FoliaScheduler.getAsyncScheduler().runAtFixedRate(this, task -> {
             if (playerSettingsManager != null) playerSettingsManager.saveAllDirty();
         }, 5, 5, TimeUnit.MINUTES);
 
@@ -123,6 +133,20 @@ public final class WorldEditDisplay extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        // Cancel scheduled tasks to prevent dangling references
+        if (shareSaveTask != null) {
+            shareSaveTask.cancel();
+            shareSaveTask = null;
+        }
+        if (expiryPurgeTask != null) {
+            expiryPurgeTask.cancel();
+            expiryPurgeTask = null;
+        }
+        if (playerSettingsSaveTask != null) {
+            playerSettingsSaveTask.cancel();
+            playerSettingsSaveTask = null;
+        }
+
         // Save share data
         if (shareManager != null) {
             shareManager.save();
@@ -137,7 +161,17 @@ public final class WorldEditDisplay extends JavaPlugin {
         if (renderManager != null) {
             renderManager.shutdown();
         }
-        
+
+        // Unregister PacketEvents listeners to prevent duplicate registrations on reload
+        if (inboundPacketListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(inboundPacketListener);
+            inboundPacketListener = null;
+        }
+        if (outboundPacketListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(outboundPacketListener);
+            outboundPacketListener = null;
+        }
+
         getLogger().info("WorldEditDisplay disabled");
     }
 

--- a/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/particle/ParticleRenderer.java
@@ -177,6 +177,7 @@ public abstract class ParticleRenderer<T extends Region> {
         edgePoints.clear();
         coloredEdgePoints.clear();
         markerPoints.clear();
+        viewers.clear();
         pointsDirty = true;
     }
 

--- a/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
+++ b/src/main/java/dev/twme/worldeditdisplay/player/PlayerData.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.entity.Player;
 
@@ -21,7 +22,7 @@ import io.github.retrooper.packetevents.util.folia.TaskWrapper;
  * Tracks current region selection(s), colors, rendering, and mode.
  */
 public class PlayerData {
-    private static final Map<UUID, PlayerData> playerDataMap = new HashMap<>();
+    private static final Map<UUID, PlayerData> playerDataMap = new ConcurrentHashMap<>();
 
     /**
      * Render mode preference for the particle-fallback feature.

--- a/src/main/java/dev/twme/worldeditdisplay/share/ShareManager.java
+++ b/src/main/java/dev/twme/worldeditdisplay/share/ShareManager.java
@@ -235,8 +235,8 @@ public class ShareManager {
     }
 
     /**
-     * Called when a player quits: clears their pending incoming invites from other players
-     * and removes their own outgoing pending invites.
+     * Called when a player quits: clears their pending invites, active shares,
+     * and viewer-to-sharer mappings to prevent memory leaks.
      */
     public void onPlayerQuit(UUID uuid) {
         // Remove pending invites sent TO this player
@@ -247,6 +247,30 @@ public class ShareManager {
 
         // Remove this player's own outgoing pending invites
         pendingRequests.remove(uuid);
+
+        // Remove this player as a sharer — revoke all active views on them
+        Set<UUID> viewers = activeShares.remove(uuid);
+        if (viewers != null) {
+            for (UUID viewerId : viewers) {
+                Set<UUID> sharers = viewerToSharers.get(viewerId);
+                if (sharers != null) {
+                    sharers.remove(uuid);
+                    if (sharers.isEmpty()) viewerToSharers.remove(viewerId);
+                }
+            }
+        }
+
+        // Remove this player as a viewer — stop watching all sharers
+        Set<UUID> sharers = viewerToSharers.remove(uuid);
+        if (sharers != null) {
+            for (UUID sharerId : sharers) {
+                Set<UUID> activeViewers = activeShares.get(sharerId);
+                if (activeViewers != null) {
+                    activeViewers.remove(uuid);
+                    if (activeViewers.isEmpty()) activeShares.remove(sharerId);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Improve memory management by enhancing player quit handling to clear active shares and prevent memory leaks. Change playerDataMap to ConcurrentHashMap for better thread safety. Add task wrappers for scheduled tasks to manage cancellations effectively. Clear viewers on reset to ensure proper state management.