### PR TITLE
chore(release): bump version to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.twme</groupId>
   <artifactId>WorldEditDisplay</artifactId>
-  <version>2.3.1</version>
+  <version>2.4.0</version>
   <packaging>jar</packaging>
 
   <name>WorldEditDisplay</name>


### PR DESCRIPTION
## Summary

- Bump the project version from `2.3.1` to `2.4.0`.
- Produce versioned Paper and Spigot artifacts through the existing `${project.version}` resource and final-name configuration.

This is a minor release because the changes merged in #59 add backward-compatible retained rendering, renderer diagnostics, CUI/state handling, command permission refinements, and shared-selection lifecycle improvements.

## Validation

- `mvn -B clean verify` (Paper): 30 tests passed; `WorldEditDisplay-2.4.0-paper.jar` produced.
- `mvn -B clean verify -Pspigot`: 30 tests passed; `WorldEditDisplay-2.4.0-spigot.jar` produced.
- Verified the packaged `plugin.yml` and Maven metadata both report version `2.4.0`.
- `git diff --check` passes.

## Release

- Proposed tag: `2.4.0`
- Proposed release title: `WorldEditDisplay 2.4.0 - Retained Rendering and Shared Selection Reliability`
- Full changelog: `2.3.1...2.4.0`
