### PR TITLE
fix: support Paper 1.19.4 and skip degenerate render lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Players can customize their own rendering preferences:
 
 ### Requirements
 
-- Minecraft 1.20 ~ 1.21.x (Paper / Folia / Spigot)
-- Java 21 or higher
+- Paper 1.19.4 ~ 26.2; Folia / Spigot 1.20 ~ 1.21.x
+- Java 17 or higher (subject to the Minecraft server version's own Java requirement)
 - Required plugins:
   - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
 
@@ -363,8 +363,8 @@ WorldEditDisplay 是一個 Minecraft 伺服器端插件，為 WorldEdit 增加�
 
 ### 需求
 
-- Minecraft 1.20 ~ 1.21.x（Paper / Folia / Spigot）
-- Java 21 或更高版本
+- Paper 1.19.4 ~ 26.2；Folia / Spigot 1.20 ~ 1.21.x
+- Java 17 或更高版本（仍須符合 Minecraft 伺服器版本本身的 Java 需求）
 - 必要插件：
   - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>WorldEditDisplay</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <platform>paper</platform>
   </properties>
@@ -26,8 +26,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
@@ -55,6 +55,7 @@ public abstract class RegionRenderer<T extends Region> {
     private Location renderOrigin;
 
     private static final double REBASE_DISTANCE_SQUARED = 80.0 * 80.0;
+    private static final float MIN_LINE_LENGTH_SQUARED = 1.0e-6f;
 
     public RegionRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
         this.plugin = plugin;
@@ -206,6 +207,8 @@ public abstract class RegionRenderer<T extends Region> {
      * Render a line using TextDisplayShapes
      */
     protected void renderLine(Line line, Color color, float thickness) {
+        if (!isRenderableLine(line)) return;
+
         if (retainedLinePassKeys != null) {
             LineKey key = LineKey.of(line, color, thickness, isSeeThrough());
             retainedLinePassKeys.add(key);
@@ -225,6 +228,15 @@ public abstract class RegionRenderer<T extends Region> {
 
         Shape shape = createLineShape(line, color, thickness);
         shapes.add(shape);
+    }
+
+    static boolean isRenderableLine(Line line) {
+        return line != null
+                && line.start() != null
+                && line.end() != null
+                && line.start().isFinite()
+                && line.end().isFinite()
+                && line.start().distanceSquared(line.end()) >= MIN_LINE_LENGTH_SQUARED;
     }
 
     private Shape createLineShape(Line line, Color color, float thickness) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: WorldEditDisplay
 version: '${project.version}'
 main: dev.twme.worldeditdisplay.WorldEditDisplay
-api-version: '1.20'
+api-version: '1.19'
 folia-supported: true
 authors: [ TWME-TW ]
 depend:

--- a/src/test/java/dev/twme/worldeditdisplay/PluginDescriptorTest.java
+++ b/src/test/java/dev/twme/worldeditdisplay/PluginDescriptorTest.java
@@ -1,0 +1,23 @@
+package dev.twme.worldeditdisplay;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+class PluginDescriptorTest {
+
+    @Test
+    void supportsPaper119() throws IOException {
+        try (InputStream stream = getClass().getResourceAsStream("/plugin.yml")) {
+            assertNotNull(stream);
+            Map<String, Object> descriptor = new Yaml().load(stream);
+            assertEquals("1.19", descriptor.get("api-version"));
+        }
+    }
+}

--- a/src/test/java/dev/twme/worldeditdisplay/display/renderer/RegionRendererTest.java
+++ b/src/test/java/dev/twme/worldeditdisplay/display/renderer/RegionRendererTest.java
@@ -1,0 +1,37 @@
+package dev.twme.worldeditdisplay.display.renderer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+class RegionRendererTest {
+
+    @Test
+    void rejectsDegenerateLineBelowShapeLibraryMinimumLength() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(1.0f, 2.0f, 3.0f),
+                new Vector3f(1.0005f, 2.0f, 3.0f));
+
+        assertFalse(RegionRenderer.isRenderableLine(line));
+    }
+
+    @Test
+    void acceptsLineAtShapeLibraryMinimumLength() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(1.0f, 2.0f, 3.0f),
+                new Vector3f(1.001f, 2.0f, 3.0f));
+
+        assertTrue(RegionRenderer.isRenderableLine(line));
+    }
+
+    @Test
+    void rejectsNonFiniteLine() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(Float.NaN, 2.0f, 3.0f),
+                new Vector3f(4.0f, 5.0f, 6.0f));
+
+        assertFalse(RegionRenderer.isRenderableLine(line));
+    }
+}


### PR DESCRIPTION
## Summary

- lower `api-version` to 1.19 so Paper 1.19.4 can load the plugin
- compile WorldEditDisplay to Java 17 bytecode and document server-specific Java requirements
- skip non-finite and sub-millimeter line segments before TextDisplayShapes validation
- add regression coverage for the plugin descriptor and line validation boundary

## Context

The 2.4.0 compatibility matrix found three failures:

1. Paper 1.19.4 rejected the plugin because `api-version` was 1.20.
2. Paper 1.19.4/1.20 legacy remappers could not inspect Java 21 class files. The shaded dependency was fixed and published by TWME-TW/TextDisplayShapes#28.
3. Cylinder tangent grids and ellipsoid pole rings generated zero-length lines, causing `IllegalArgumentException: line endpoints must be distinct` and partial renders.

The common `renderLine` boundary now uses the same squared-length threshold (`1e-6`) as TextDisplayShapes, which also protects other renderers from invalid generated geometry.

## Verification

- `mvn clean package`: 34 tests passed
- clean Maven repository build against published TextDisplayShapes snapshot build 6
- verified every class in the shaded JAR is class file major 61 or lower
- exercised five CUI region types on the latest stable Paper build for all 21 released versions from 1.19.4 through 26.2
- all 21 versions produced positive renderer/retained-line counts and client-side `text_display` spawn packets
- no WED renderer, API-version, invalid-plugin, or legacy-remapper errors in the final logs

Paper versions tested: 1.19.4; 1.20, 1.20.1, 1.20.2, 1.20.4, 1.20.5, 1.20.6; 1.21, 1.21.1, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.21.7, 1.21.8, 1.21.9, 1.21.10, 1.21.11; 26.1.1, 26.1.2, 26.2. The 26.2 client packet check used a 26.1.2 Mineflayer client through ViaVersion/ViaBackwards because `minecraft-data` does not yet ship a 26.2 registry; the Paper 26.2 server and WED execution were native.