### PR TITLE
feat: migrate rendering to VirtualEntities 0.9.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: Paper Mineflayer E2E
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: integration/mineflayer/package-lock.json
+      - name: Run Paper and Mineflayer test
+        run: ./integration/mineflayer/run-e2e.sh

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: CI
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B verify --file pom.xml
       - name: Upload JAR
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - name: Build release artifact
+        run: mvn -B clean package
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          target/WorldEditDisplay-*-paper.jar
+          --title "WorldEditDisplay ${GITHUB_REF_NAME}"
+          --generate-notes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A server-side WorldEdit selection visualization plugin | WorldEdit 選區視覺�
 
 WorldEditDisplay is a server-side plugin for Minecraft that adds visual selection rendering for WorldEdit. It intercepts WorldEdit's CUI (Client User Interface) protocol packets and renders selections using Display Entities on the server side. This means players can see their WorldEdit selections without installing any client-side mods.
 
-Version 2.5.0 is based on upstream WorldEditDisplay 2.4.0 commit `9625ec0`. It preserves the retained-line renderer and expanded debug statistics while migrating all packet-only selection shapes and shared-player labels from EntityLib to [VirtualEntities](https://github.com/twme-ai/VirtualEntities), using the [twme-ai/TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) 3.0.0 packet module.
+Version 2.5.0 preserves the retained-line renderer and expanded debug statistics while migrating all packet-only selection shapes and shared-player labels from EntityLib to [VirtualEntities](https://github.com/twme-ai/VirtualEntities) v0.9.0, using the [TWME-TW/TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) 3.0.0 packet module.
 
 ### Features
 
@@ -313,9 +313,8 @@ See [LICENSE](LICENSE) file for details.
 - [WorldEdit](https://github.com/EngineHub/WorldEdit) - The core editing tool
 - [WorldEditCUI](https://github.com/EngineHub/WorldEditCUI) - Client-side CUI mod (protocol reference)
 - [PacketEvents](https://github.com/retrooper/packetevents) - Packet handling library
-- [TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) - VirtualEntities-based shape rendering library used by the plugin
+- [TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - VirtualEntities-based shape rendering library used by the plugin
 - [VirtualEntities](https://github.com/twme-ai/VirtualEntities) - Packet-only entity lifecycle and metadata library used by TextDisplayShapes and shared labels
-- [TWME-TW/TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - Upstream TextDisplayShapes project
 
 ---
 
@@ -610,9 +609,8 @@ src/main/java/dev/twme/worldeditdisplay/
 - [WorldEdit](https://github.com/EngineHub/WorldEdit) - 核心編輯工具
 - [WorldEditCUI](https://github.com/EngineHub/WorldEditCUI) - 客戶端 CUI 模組（協議參考）
 - [PacketEvents](https://github.com/retrooper/packetevents) - 封包處理函式庫
-- [TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) - 此插件使用、基於 VirtualEntities 的形狀渲染函式庫
+- [TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - 此插件使用、基於 VirtualEntities 的形狀渲染函式庫
 - [VirtualEntities](https://github.com/twme-ai/VirtualEntities) - TextDisplayShapes 與共享標籤使用的封包虛擬實體生命週期與 metadata 函式庫
-- [TWME-TW/TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - TextDisplayShapes 上游專案
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Players can customize their own rendering preferences:
 
 ### Requirements
 
-- Minecraft 1.20 ~ 1.21.x (Paper / Folia / Spigot)
-- Java 21 or higher
+- Paper 1.19.4 ~ 26.2; Folia / Spigot 1.20 ~ 1.21.x
+- Java 17 or higher (subject to the Minecraft server version's own Java requirement)
 - Required plugins:
   - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
 
@@ -363,8 +363,8 @@ WorldEditDisplay 是一個 Minecraft 伺服器端插件，為 WorldEdit 增加�
 
 ### 需求
 
-- Minecraft 1.20 ~ 1.21.x（Paper / Folia / Spigot）
-- Java 21 或更高版本
+- Paper 1.19.4 ~ 26.2；Folia / Spigot 1.20 ~ 1.21.x
+- Java 17 或更高版本（仍須符合 Minecraft 伺服器版本本身的 Java 需求）
 - 必要插件：
   - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A server-side WorldEdit selection visualization plugin | WorldEdit 選區視覺�
 
 WorldEditDisplay is a server-side plugin for Minecraft that adds visual selection rendering for WorldEdit. It intercepts WorldEdit's CUI (Client User Interface) protocol packets and renders selections using Display Entities on the server side. This means players can see their WorldEdit selections without installing any client-side mods.
 
-Version 2.4.0 migrates all packet-only selection shapes and shared-player labels from EntityLib to [VirtualEntities](https://github.com/twme-ai/VirtualEntities), using the [twme-ai/TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) 3.0.0 packet module.
+Version 2.5.0 is based on upstream WorldEditDisplay 2.4.0 commit `9625ec0`. It preserves the retained-line renderer and expanded debug statistics while migrating all packet-only selection shapes and shared-player labels from EntityLib to [VirtualEntities](https://github.com/twme-ai/VirtualEntities), using the [twme-ai/TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) 3.0.0 packet module.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A server-side WorldEdit selection visualization plugin | WorldEdit 選區視覺�
 
 WorldEditDisplay is a server-side plugin for Minecraft that adds visual selection rendering for WorldEdit. It intercepts WorldEdit's CUI (Client User Interface) protocol packets and renders selections using Display Entities on the server side. This means players can see their WorldEdit selections without installing any client-side mods.
 
+Version 2.4.0 migrates all packet-only selection shapes and shared-player labels from EntityLib to [VirtualEntities](https://github.com/twme-ai/VirtualEntities), using the [twme-ai/TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) 3.0.0 packet module.
+
 ### Features
 
 **Selection Types**
@@ -71,7 +73,7 @@ Players can customize their own rendering preferences:
 - Paper 1.19.4 ~ 26.2; Folia / Spigot 1.20 ~ 1.21.x
 - Java 17 or higher (subject to the Minecraft server version's own Java requirement)
 - Required plugins:
-  - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
+  - [PacketEvents](https://github.com/retrooper/packetevents) 2.13.0+
 
 ### Installation
 
@@ -275,6 +277,12 @@ mvn clean package
 
 The compiled jar will be in `target/WorldEditDisplay-version-platform.jar`
 
+Run the full Paper 1.21.11, PacketEvents 2.13.0, and Mineflayer CUI rendering test with:
+
+```bash
+./integration/mineflayer/run-e2e.sh
+```
+
 **Project Structure**
 ```
 src/main/java/dev/twme/worldeditdisplay/
@@ -305,7 +313,9 @@ See [LICENSE](LICENSE) file for details.
 - [WorldEdit](https://github.com/EngineHub/WorldEdit) - The core editing tool
 - [WorldEditCUI](https://github.com/EngineHub/WorldEditCUI) - Client-side CUI mod (protocol reference)
 - [PacketEvents](https://github.com/retrooper/packetevents) - Packet handling library
-- [TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - Shape rendering library used by the plugin
+- [TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) - VirtualEntities-based shape rendering library used by the plugin
+- [VirtualEntities](https://github.com/twme-ai/VirtualEntities) - Packet-only entity lifecycle and metadata library used by TextDisplayShapes and shared labels
+- [TWME-TW/TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - Upstream TextDisplayShapes project
 
 ---
 
@@ -366,7 +376,7 @@ WorldEditDisplay 是一個 Minecraft 伺服器端插件，為 WorldEdit 增加�
 - Paper 1.19.4 ~ 26.2；Folia / Spigot 1.20 ~ 1.21.x
 - Java 17 或更高版本（仍須符合 Minecraft 伺服器版本本身的 Java 需求）
 - 必要插件：
-  - [PacketEvents](https://github.com/retrooper/packetevents) 2.11.1+
+  - [PacketEvents](https://github.com/retrooper/packetevents) 2.13.0+
 
 ### 安裝
 
@@ -600,7 +610,9 @@ src/main/java/dev/twme/worldeditdisplay/
 - [WorldEdit](https://github.com/EngineHub/WorldEdit) - 核心編輯工具
 - [WorldEditCUI](https://github.com/EngineHub/WorldEditCUI) - 客戶端 CUI 模組（協議參考）
 - [PacketEvents](https://github.com/retrooper/packetevents) - 封包處理函式庫
-- [TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - 此插件使用的形狀渲染函式庫
+- [TextDisplayShapes](https://github.com/twme-ai/TextDisplayShapes) - 此插件使用、基於 VirtualEntities 的形狀渲染函式庫
+- [VirtualEntities](https://github.com/twme-ai/VirtualEntities) - TextDisplayShapes 與共享標籤使用的封包虛擬實體生命週期與 metadata 函式庫
+- [TWME-TW/TextDisplayShapes](https://github.com/TWME-TW/TextDisplayShapes) - TextDisplayShapes 上游專案
 
 ---
 

--- a/integration/mineflayer/.gitignore
+++ b/integration/mineflayer/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/integration/mineflayer/package-lock.json
+++ b/integration/mineflayer/package-lock.json
@@ -1,0 +1,955 @@
+{
+  "name": "worldeditdisplay-mineflayer-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "worldeditdisplay-mineflayer-e2e",
+      "dependencies": {
+        "mineflayer": "4.37.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.3.tgz",
+      "integrity": "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/node-rsa": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node-rsa/-/node-rsa-1.1.4.tgz",
+      "integrity": "sha512-dB0ECel6JpMnq5ULvpUTunx3yNm8e/dIkv8Zu9p2c8me70xIRUUG3q+qXRwcSf9rN3oqamv4116iHy90dJGRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xboxreplay/xboxlive-auth": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/xboxlive-auth/-/xboxlive-auth-5.1.0.tgz",
+      "integrity": "sha512-UngHHsehZbiTjyyNmo8HvdoUDKMID1U9uVfrpFWUK/2UxPuVTKy5n+CzZQ3S488sW5vOhgh0lHqqynT8ouwgvw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha512-6i37w/+EhlWlGUJff3T/Q8u1RGmP5wgbiwYnOnbOqvtrPxT63/sYFyP9RcpxtxGymtfA075IvmOnL7ycNOWl3w==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/endian-toggle": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",
+      "integrity": "sha512-ShfqhXeHRE4TmggSlHXG8CMGIcsOsqDw/GcoPcosToE59Rm9e4aXaMhEQf2kPBsBRrKem1bbOAv5gOKnkliMFQ==",
+      "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
+      "license": "MIT"
+    },
+    "node_modules/macaddress": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.5.4.tgz",
+      "integrity": "sha512-i8xVWoUjj2woYU8kbpQby86Kq7uF7xl2brtKREXUBWpfgqx1fKXEeYzDiVMVxA/IufC1d3xxwJRHtFCX+9IspA==",
+      "license": "MIT"
+    },
+    "node_modules/minecraft-data": {
+      "version": "3.111.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.111.0.tgz",
+      "integrity": "sha512-0kKHqNZL/D1IbH7tJXBJ3z7YSn1/ylnWWR7X2zFwtEV+yr23nimItpGjP3o8UaLYrC+OV1gKLFQoew03XvJyoA==",
+      "license": "MIT"
+    },
+    "node_modules/minecraft-folder-path": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minecraft-folder-path/-/minecraft-folder-path-1.2.0.tgz",
+      "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw==",
+      "license": "MIT"
+    },
+    "node_modules/minecraft-protocol": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.66.2.tgz",
+      "integrity": "sha512-keY1IY1E2AeurcekCfcXrg0TDbykGVFiMe1E4wR8QkNtQRieNwfr2xaF3g3vT9ChkwzvENqp3jxgmtFCKSUKPg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/node-rsa": "^1.1.4",
+        "@types/readable-stream": "^4.0.0",
+        "aes-js": "^3.1.2",
+        "buffer-equal": "^1.0.0",
+        "debug": "^4.3.2",
+        "endian-toggle": "^0.0.0",
+        "lodash.merge": "^4.3.0",
+        "minecraft-data": "^3.78.0",
+        "minecraft-folder-path": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "node-rsa": "^0.4.2",
+        "prismarine-auth": "^3.1.1",
+        "prismarine-chat": "^1.10.0",
+        "prismarine-nbt": "^2.5.0",
+        "prismarine-realms": "^1.2.0",
+        "protodef": "^1.17.0",
+        "readable-stream": "^4.1.0",
+        "uuid-1345": "^1.0.1",
+        "yggdrasil": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/mineflayer": {
+      "version": "4.37.1",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.37.1.tgz",
+      "integrity": "sha512-kchZCJb1znzz8ZhE0+gLQ3e2t/9xUsqUy/IM/sGfceINxi3h6KXKY9luaUEa59vnD/x0OKwYdERY4sscm0ErNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.108.0",
+        "minecraft-protocol": "^1.66.0",
+        "mojangson": "^2.0.4",
+        "prismarine-biome": "^1.1.1",
+        "prismarine-block": "^1.22.0",
+        "prismarine-chat": "^1.7.1",
+        "prismarine-chunk": "^1.39.0",
+        "prismarine-entity": "^2.5.0",
+        "prismarine-item": "^1.17.0",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-physics": "^1.9.0",
+        "prismarine-recipe": "^1.5.0",
+        "prismarine-registry": "^1.10.0",
+        "prismarine-windows": "^2.9.0",
+        "prismarine-world": "^3.6.0",
+        "protodef": "^1.18.0",
+        "typed-emitter": "^1.0.0",
+        "uuid-1345": "^1.0.2",
+        "vec3": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/mojangson": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mojangson/-/mojangson-2.0.4.tgz",
+      "integrity": "sha512-HYmhgDjr1gzF7trGgvcC/huIg2L8FsVbi/KacRe6r1AswbboGVZDS47SOZlomPuMWvZLas8m9vuHHucdZMwTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "nearley": "^2.19.5"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-rsa": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
+      "integrity": "sha512-Bvso6Zi9LY4otIZefYrscsUpo2mUpiAVIEmSZV2q41sP8tHZoert3Yu6zv4f/RXJqMNZQKCtnhDugIuCma23YA==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "0.2.3"
+      }
+    },
+    "node_modules/prismarine-auth": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-3.1.1.tgz",
+      "integrity": "sha512-NuNrMGZdoigFKsvi1ZZgAEvNYNuE5qe6lo/tw+bqeNbkhpjHC0u1JNxLEujnfqduXI18e19PvUtWNMDl/gH7yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-node": "^2.0.2",
+        "@xboxreplay/xboxlive-auth": "^5.1.0",
+        "debug": "^4.3.3",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
+    "node_modules/prismarine-biome": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.4.0.tgz",
+      "integrity": "sha512-fD2WmjN8Zr/xA/jeMInReLgaDlznwA5xlaK529PzWuGzgjpc5ijVu1Lp1oqHyZn3WxOG/bRVtW1bU+tmgCurWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prismarine-registry": "^1.1.0"
+      }
+    },
+    "node_modules/prismarine-block": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.23.0.tgz",
+      "integrity": "sha512-j2UoU4KbXMvNlBw+aLkMOnEuMayYefznUfbrfv1VIbckG3RA9LpNWltOMHXuOR5YkHp8uIZPOclj95XC88jgGw==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.38.0",
+        "prismarine-biome": "^1.1.0",
+        "prismarine-chat": "^1.5.0",
+        "prismarine-item": "^1.10.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.1.0"
+      }
+    },
+    "node_modules/prismarine-chat": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chat/-/prismarine-chat-1.13.0.tgz",
+      "integrity": "sha512-tvDbrQmJEoy09yLE5nnedGhQYxnRDaPRePMv7W39dFaHr2LGcA2JfCmH0vG5193+BsEFz3a5+0EpQSK8OW7YmA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "mojangson": "^2.0.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-chunk": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.40.0.tgz",
+      "integrity": "sha512-TtT84Bys7+aGA94HwcK0QDp+jkWcLOLErKYtaWWl+EJya28NqPoBASr5L/lPZ8ZWLQUugg/aFIefZI/rEhEQWw==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-biome": "^1.2.0",
+        "prismarine-block": "^1.14.1",
+        "prismarine-nbt": "^2.2.1",
+        "prismarine-registry": "^1.1.0",
+        "smart-buffer": "^4.1.0",
+        "uint4": "^0.1.2",
+        "vec3": "^0.1.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/prismarine-entity": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prismarine-entity/-/prismarine-entity-2.6.0.tgz",
+      "integrity": "sha512-/LlZRLOpACiXk+GqoaKi0XPBFnNMjb1d4OIzuSCSEgNMK6FUo3Wnin5yeSZ7ff3Ztt7yagN9lX2jSOafn6IIzg==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-chat": "^1.4.1",
+        "prismarine-item": "^1.11.2",
+        "prismarine-registry": "^1.4.0",
+        "vec3": "^0.1.4"
+      }
+    },
+    "node_modules/prismarine-item": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/prismarine-item/-/prismarine-item-1.18.0.tgz",
+      "integrity": "sha512-8pEq6YfcneVvarvUFnex09a3+MR8/4NCQVyawIKAa3kh/g9dHLexoEcpQEgM3cmpg4gbLmspSiARGwed5uGhlg==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-nbt": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.8.0.tgz",
+      "integrity": "sha512-5D6FUZq0PNtf3v/41ImDlwThVesOv5adyqCRMZLzmkUGEmRJNNh5C6AsnvrClBftXs+IF0yqPnZoj8kcNPiMGg==",
+      "license": "MIT",
+      "dependencies": {
+        "protodef": "^1.18.0"
+      }
+    },
+    "node_modules/prismarine-physics": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/prismarine-physics/-/prismarine-physics-1.11.0.tgz",
+      "integrity": "sha512-P25VSDi3kJHQAb/AJBiJCQuxyRCVXRSdEiDjx56ywocgt65N/exatVTiJjOK5HgEKHJSfw0sXSAohQhvutnGAA==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.0.0",
+        "prismarine-nbt": "^2.0.0",
+        "vec3": "^0.1.7"
+      }
+    },
+    "node_modules/prismarine-realms": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/prismarine-realms/-/prismarine-realms-1.6.0.tgz",
+      "integrity": "sha512-AwemW0vwxG9hQaFtg1twSV7eymB6QtYxGK0jjpxfdA2sdK15kU8jh8uD1o5XF0oxSMU+BbpzZMCmXtXq4QE6bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.3",
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/prismarine-recipe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prismarine-recipe/-/prismarine-recipe-1.5.0.tgz",
+      "integrity": "sha512-GRZHbsyBIUgVNF10vFRv2YWZj86vokCT5EWX6iK6gfx6h4FapgZT29V2DNkjv5+hmdzBCLZvfx1/RYr8VPeoGQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-registry": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prismarine-registry/-/prismarine-registry-1.12.0.tgz",
+      "integrity": "sha512-OC5U6YrflY6OcAWRZEqe2HGZuNp0bIuP7H+oKEHD6rLfKNDxo8Ymx5eh2VvrZWnMVugpwID1Qj/UjA4MoCzNDw==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.70.0",
+        "prismarine-block": "^1.17.1",
+        "prismarine-nbt": "^2.0.0"
+      }
+    },
+    "node_modules/prismarine-windows": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/prismarine-windows/-/prismarine-windows-2.10.0.tgz",
+      "integrity": "sha512-ssXLGAr7W9JLvvLjYMoo1j4j6AdJaoIb0/HlqkWMWlQqvZJeiS4zyBjJY6+GtR4OzpjkEf6IvF5cNXhHFpbcZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-item": "^1.12.2",
+        "prismarine-registry": "^1.7.0",
+        "typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/prismarine-windows/node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
+    "node_modules/prismarine-world": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/prismarine-world/-/prismarine-world-3.7.0.tgz",
+      "integrity": "sha512-M5euvNjQ3vIk689BSa0YC6PBwpVY35Oc6q6KyZ0IqyFtI+cQ9em+8l5OTAK/uu9/gzDDhR7cmm9L2WXgTXBQCw==",
+      "license": "MIT",
+      "dependencies": {
+        "vec3": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/protodef": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/protodef/-/protodef-1.19.0.tgz",
+      "integrity": "sha512-94f3GR7pk4Qi5YVLaLvWBfTGUIzzO8hyo7vFVICQuu5f5nwKtgGDaeC1uXIu49s5to/49QQhEYeL0aigu1jEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.reduce": "^4.6.0",
+        "protodef-validator": "^1.3.0",
+        "readable-stream": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/protodef-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/protodef-validator/-/protodef-validator-1.4.0.tgz",
+      "integrity": "sha512-2y2coBolqCEuk5Kc3QwO7ThR+/7TZiOit4FrpAgl+vFMvq8w76nDhh09z08e2NQOdrgPLsN2yzXsvRvtADgUZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.5.4"
+      },
+      "bin": {
+        "protodef-validator": "cli.js"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typed-emitter": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+      "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg==",
+      "license": "MIT"
+    },
+    "node_modules/uint4": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uint4/-/uint4-0.1.2.tgz",
+      "integrity": "sha512-lhEx78gdTwFWG+mt6cWAZD/R6qrIj0TTBeH5xwyuDJyswLNlGe+KVlUPQ6+mx5Ld332pS0AMUTo9hIly7YsWxQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-1345": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-1.0.2.tgz",
+      "integrity": "sha512-bA5zYZui+3nwAc0s3VdGQGBfbVsJLVX7Np7ch2aqcEWFi5lsAEcmO3+lx3djM1npgpZI8KY2FITZ2uYTnYUYyw==",
+      "license": "MIT",
+      "dependencies": {
+        "macaddress": "^0.5.1"
+      }
+    },
+    "node_modules/vec3": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/vec3/-/vec3-0.1.10.tgz",
+      "integrity": "sha512-Sr1U3mYtMqCOonGd3LAN9iqy0qF6C+Gjil92awyK/i2OwiUo9bm7PnLgFpafymun50mOjnDcg4ToTgRssrlTcw==",
+      "license": "BSD"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
+      "license": "MIT"
+    },
+    "node_modules/yggdrasil": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/yggdrasil/-/yggdrasil-1.8.0.tgz",
+      "integrity": "sha512-r5bKOhkZ52DJ6q034uSkdsdZLoFVhOmfDOagRs6h/JX5W7+XIPOMb+peCbElhLEoIckwt43NCUoNQbydOzuPcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/yggdrasil/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  }
+}

--- a/integration/mineflayer/package.json
+++ b/integration/mineflayer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "worldeditdisplay-mineflayer-e2e",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "mineflayer": "4.37.1"
+  }
+}

--- a/integration/mineflayer/run-e2e.sh
+++ b/integration/mineflayer/run-e2e.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly PAPER_API="https://fill.papermc.io/v3/projects/paper/versions/1.21.11/builds/latest"
+readonly PACKETEVENTS_URL="https://github.com/retrooper/packetevents/releases/download/v2.13.0/packetevents-spigot-2.13.0.jar"
+readonly PACKETEVENTS_SHA256="6d9ece0d87ee727a79a20b7ffbd432021609c6f52bafcb654fc2d3e9b6f064c5"
+readonly PORT="${WED_E2E_PORT:-$(node -e 'const net=require("net");const server=net.createServer();server.listen(0,"127.0.0.1",()=>{console.log(server.address().port);server.close()})')}"
+readonly TEMP_DIR="$(mktemp -d)"
+readonly SERVER_DIR="${TEMP_DIR}/server"
+readonly CACHE_DIR="${PROJECT_DIR}/target/mineflayer-cache"
+readonly PAPER_JAR="${CACHE_DIR}/paper-1.21.11.jar"
+readonly PACKETEVENTS_JAR="${CACHE_DIR}/packetevents-spigot-2.13.0.jar"
+readonly INTEGRATION_JAR="${PROJECT_DIR}/integration/paper-plugin/target/WorldEditDisplayIntegration.jar"
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+      if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "${SERVER_PID}" 2>/dev/null; then
+      kill -KILL "${SERVER_PID}" 2>/dev/null || true
+    fi
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+mvn -B clean package
+mvn -B -f "${PROJECT_DIR}/integration/paper-plugin/pom.xml" clean package
+
+mkdir -p "${CACHE_DIR}" "${SERVER_DIR}/plugins"
+
+mapfile -t plugin_jars < <(find "${PROJECT_DIR}/target" -maxdepth 1 -type f -name 'WorldEditDisplay-*-paper.jar' -print)
+if [[ "${#plugin_jars[@]}" -ne 1 ]]; then
+  echo "Expected exactly one WorldEditDisplay paper JAR, found ${#plugin_jars[@]}" >&2
+  exit 1
+fi
+
+paper_metadata="$(curl --fail --silent --show-error --location "${PAPER_API}")"
+paper_url="$(jq -er '.downloads["server:default"].url' <<<"${paper_metadata}")"
+paper_sha256="$(jq -er '.downloads["server:default"].checksums.sha256' <<<"${paper_metadata}")"
+if [[ ! -f "${PAPER_JAR}" ]] || ! echo "${paper_sha256}  ${PAPER_JAR}" | sha256sum --check --status; then
+  curl --fail --silent --show-error --location "${paper_url}" --output "${PAPER_JAR}"
+fi
+echo "${paper_sha256}  ${PAPER_JAR}" | sha256sum --check --status
+
+if [[ ! -f "${PACKETEVENTS_JAR}" ]] || ! echo "${PACKETEVENTS_SHA256}  ${PACKETEVENTS_JAR}" | sha256sum --check --status; then
+  curl --fail --silent --show-error --location "${PACKETEVENTS_URL}" --output "${PACKETEVENTS_JAR}"
+fi
+echo "${PACKETEVENTS_SHA256}  ${PACKETEVENTS_JAR}" | sha256sum --check --status
+
+cp "${PAPER_JAR}" "${SERVER_DIR}/paper.jar"
+cp "${PACKETEVENTS_JAR}" "${SERVER_DIR}/plugins/packetevents.jar"
+cp "${plugin_jars[0]}" "${SERVER_DIR}/plugins/WorldEditDisplay.jar"
+cp "${INTEGRATION_JAR}" "${SERVER_DIR}/plugins/WorldEditDisplayIntegration.jar"
+
+printf 'eula=true\n' >"${SERVER_DIR}/eula.txt"
+printf '%s\n' \
+  "server-port=${PORT}" \
+  'online-mode=false' \
+  'spawn-protection=0' \
+  'view-distance=4' \
+  'simulation-distance=4' \
+  'level-type=minecraft:flat' \
+  'motd=WorldEditDisplay integration test' \
+  >"${SERVER_DIR}/server.properties"
+
+pushd "${SERVER_DIR}" >/dev/null
+java -Xms512M -Xmx1G -jar paper.jar --nogui >server.log 2>&1 &
+SERVER_PID="$!"
+popd >/dev/null
+
+for _ in $(seq 1 180); do
+  if grep -q 'Done (' "${SERVER_DIR}/server.log" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    tail -160 "${SERVER_DIR}/server.log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+if ! grep -q 'Done (' "${SERVER_DIR}/server.log"; then
+  tail -160 "${SERVER_DIR}/server.log" >&2
+  echo "Paper did not start within 180 seconds" >&2
+  exit 1
+fi
+if ! grep -q 'Enabling WorldEditDisplay v2.4.0' "${SERVER_DIR}/server.log"; then
+  tail -160 "${SERVER_DIR}/server.log" >&2
+  echo "WorldEditDisplay 2.4.0 did not enable" >&2
+  exit 1
+fi
+
+npm ci --prefix "${PROJECT_DIR}/integration/mineflayer" --silent
+if ! WED_E2E_PORT="${PORT}" node "${PROJECT_DIR}/integration/mineflayer/test.mjs"; then
+  tail -200 "${SERVER_DIR}/server.log" >&2
+  exit 1
+fi

--- a/integration/mineflayer/run-e2e.sh
+++ b/integration/mineflayer/run-e2e.sh
@@ -92,9 +92,9 @@ if ! grep -q 'Done (' "${SERVER_DIR}/server.log"; then
   echo "Paper did not start within 180 seconds" >&2
   exit 1
 fi
-if ! grep -q 'Enabling WorldEditDisplay v2.4.0' "${SERVER_DIR}/server.log"; then
+if ! grep -q 'Enabling WorldEditDisplay v2.5.0' "${SERVER_DIR}/server.log"; then
   tail -160 "${SERVER_DIR}/server.log" >&2
-  echo "WorldEditDisplay 2.4.0 did not enable" >&2
+  echo "WorldEditDisplay 2.5.0 did not enable" >&2
   exit 1
 fi
 

--- a/integration/mineflayer/test.mjs
+++ b/integration/mineflayer/test.mjs
@@ -60,23 +60,104 @@ function waitForMetadata(bot, entity, predicate, description) {
   })
 }
 
-const bot = mineflayer.createBot({
-  host: '127.0.0.1',
-  port,
-  username: 'WEDClient',
-  version: '1.21.11',
-  auth: 'offline'
-})
-
-const fatal = (error) => {
-  console.error(error)
-  process.exitCode = 1
-  bot.quit('e2e failed')
+function componentText(component) {
+  if (typeof component === 'string') return component
+  if (!component || typeof component !== 'object') return ''
+  if (typeof component.value === 'string') return component.value
+  if (component.type === 'compound' && component.value) {
+    const text = componentText(component.value.text)
+    const extra = Array.isArray(component.value.extra)
+      ? component.value.extra.map(componentText).join('')
+      : ''
+    return text + extra
+  }
+  if (typeof component.text === 'string') return component.text
+  if (Array.isArray(component.extra)) return component.extra.map(componentText).join('')
+  return ''
 }
 
-try {
-  await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => fail(new Error('Timed out waiting for Mineflayer spawn')), timeoutMs)
+function waitForTextDisplayText(bot, expected) {
+  const textIndex = bot.registry.entitiesByName.text_display.metadataKeys.indexOf('text')
+  if (textIndex < 0) {
+    return Promise.reject(new Error('Mineflayer registry does not expose Text Display text metadata'))
+  }
+
+  return new Promise((resolve, reject) => {
+    const matches = entity => entity.name === 'text_display'
+      && componentText(entity.metadata[textIndex]) === expected
+    const current = Object.values(bot.entities).find(matches)
+    if (current) {
+      resolve(current)
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      bot.removeListener('entitySpawn', listener)
+      bot.removeListener('entityUpdate', listener)
+      const displays = Object.values(bot.entities)
+        .filter(entity => entity.name === 'text_display')
+      const uniqueTexts = [...new Map(displays
+        .map(entity => ({
+          id: entity.id,
+          parsed: componentText(entity.metadata[textIndex]),
+          raw: entity.metadata[textIndex]
+        }))
+        .filter(entry => entry.raw !== undefined)
+        .map(entry => [JSON.stringify(entry.raw), entry]))
+        .values()]
+      reject(new Error(`Timed out waiting for shared label text: ${expected}; displays=${displays.length}; uniqueTexts=${JSON.stringify(uniqueTexts)}`))
+    }, timeoutMs)
+    const listener = entity => {
+      if (!matches(entity)) return
+      clearTimeout(timeout)
+      bot.removeListener('entitySpawn', listener)
+      bot.removeListener('entityUpdate', listener)
+      resolve(entity)
+    }
+    bot.on('entitySpawn', listener)
+    bot.on('entityUpdate', listener)
+  })
+}
+
+function waitForTextDisplayCount(bot, expectedMinimum) {
+  const count = () => Object.values(bot.entities)
+    .filter(entity => entity.name === 'text_display')
+    .length
+
+  return new Promise((resolve, reject) => {
+    const current = count()
+    if (current >= expectedMinimum) {
+      resolve(current)
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      bot.removeListener('entitySpawn', listener)
+      reject(new Error(`Timed out waiting for ${expectedMinimum} Text Display entities; received ${count()}`))
+    }, timeoutMs)
+    const listener = entity => {
+      if (entity.name !== 'text_display') return
+      const currentCount = count()
+      if (currentCount < expectedMinimum) return
+      clearTimeout(timeout)
+      bot.removeListener('entitySpawn', listener)
+      resolve(currentCount)
+    }
+    bot.on('entitySpawn', listener)
+  })
+}
+
+function createAndSpawnBot(username) {
+  const bot = mineflayer.createBot({
+    host: '127.0.0.1',
+    port,
+    username,
+    version: '1.21.11',
+    auth: 'offline'
+  })
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => fail(new Error(`Timed out waiting for ${username} spawn`)), timeoutMs)
     const cleanup = () => {
       clearTimeout(timeout)
       bot.removeListener('spawn', spawned)
@@ -85,55 +166,109 @@ try {
     }
     const spawned = () => {
       cleanup()
-      resolve()
+      resolve(bot)
     }
-    const fail = (error) => {
+    const fail = error => {
       cleanup()
       reject(error)
     }
-    const kicked = (reason) => fail(new Error(`Mineflayer was kicked: ${reason}`))
+    const kicked = reason => fail(new Error(`${username} was kicked: ${reason}`))
     bot.once('spawn', spawned)
     bot.once('error', fail)
     bot.once('kicked', kicked)
   })
+}
 
-  bot.once('error', fatal)
-  bot.once('kicked', reason => fatal(new Error(`Mineflayer was kicked: ${reason}`)))
+const bots = []
+const fatal = (error) => {
+  console.error(error)
+  process.exitCode = 1
+  for (const bot of bots) bot.quit('e2e failed')
+}
 
-  const readyMessage = waitForMessage(bot, 'WED_READY:')
-  bot.chat('/wedtest')
+try {
+  const sharer = await createAndSpawnBot('WEDSharer')
+  bots.push(sharer)
+  const viewer = await createAndSpawnBot('WEDViewer')
+  bots.push(viewer)
+
+  sharer.once('error', fatal)
+  sharer.once('kicked', reason => fatal(new Error(`WEDSharer was kicked: ${reason}`)))
+  viewer.once('error', fatal)
+  viewer.once('kicked', reason => fatal(new Error(`WEDViewer was kicked: ${reason}`)))
+
+  const debugEnabledMessage = waitForMessage(sharer, 'Debug mode enabled')
+  sharer.chat('/wedisplay debug')
+  await debugEnabledMessage
+
+  const readyMessage = waitForMessage(sharer, 'WED_READY:')
+  const retainedLineCountMessage = waitForMessage(sharer, 'Retained line shapes:')
+  const retainedLinePassMessage = waitForMessage(sharer, 'Last line pass reused/spawned/removed:')
+  sharer.chat('/wedtest')
   const ready = await readyMessage
-  const entityCount = Number(ready.substring(ready.indexOf('WED_READY:') + 'WED_READY:'.length).trim())
-  if (!Number.isInteger(entityCount) || entityCount <= 0) {
+  await Promise.all([retainedLineCountMessage, retainedLinePassMessage])
+
+  const state = ready
+    .substring(ready.indexOf('WED_READY:') + 'WED_READY:'.length)
+    .trim()
+    .split(':')
+    .map(Number)
+  if (state.length !== 6 || state.some(value => !Number.isInteger(value))) {
     throw new Error(`WorldEditDisplay reported an invalid entity count: ${ready}`)
   }
+  const [entityCount, retainedLineCount, retainedLineEntityCount, reusedLines, spawnedLines, removedLines] = state
+  if (entityCount <= 0 || retainedLineCount <= 0 || retainedLineEntityCount <= 0) {
+    throw new Error(`WorldEditDisplay reported invalid retained renderer state: ${ready}`)
+  }
+  if (reusedLines <= 0 || spawnedLines !== 0 || removedLines !== 0) {
+    throw new Error(`WorldEditDisplay did not reuse the retained VirtualEntities shapes: ${ready}`)
+  }
 
-  const entity = await waitForTextDisplay(bot)
-  const translationIndex = bot.registry.entitiesByName.text_display.metadataKeys.indexOf('translation')
+  const entity = await waitForTextDisplay(sharer)
+  const translationIndex = sharer.registry.entitiesByName.text_display.metadataKeys.indexOf('translation')
   if (translationIndex < 0) {
     throw new Error('Mineflayer registry does not expose Text Display translation metadata')
   }
   await waitForMetadata(
-    bot,
+    sharer,
     entity,
     current => Number.isFinite(current.metadata[translationIndex]?.x),
     'WorldEditDisplay Text Display translation metadata'
   )
 
-  const visibleTextDisplays = Object.values(bot.entities)
+  const visibleTextDisplays = Object.values(sharer.entities)
     .filter(current => current.name === 'text_display')
     .length
   if (visibleTextDisplays <= 0) {
     throw new Error('WorldEditDisplay did not leave any visible Text Display entities')
   }
 
+  const inviteReceived = waitForMessage(viewer, 'wants to share their selection with you')
+  sharer.chat('/wedisplay share invite WEDViewer')
+  await inviteReceived
+
+  const sharedLabelPromise = waitForTextDisplayText(viewer, 'WEDSharer')
+  const acceptedMessage = waitForMessage(viewer, 'You are now viewing WEDSharer')
+  viewer.chat('/wedisplay share accept WEDSharer')
+  await acceptedMessage
+  const sharedLabel = await sharedLabelPromise
+  const viewerTextDisplays = await waitForTextDisplayCount(viewer, visibleTextDisplays + 1)
+
   console.log(JSON.stringify({
     managerInitialized: true,
     rendererEntities: entityCount,
+    retainedLineCount,
+    retainedLineEntityCount,
+    retainedLinePass: { reusedLines, spawnedLines, removedLines },
+    debugMessagesObserved: true,
     visibleTextDisplays,
+    sharedViewerTextDisplays: viewerTextDisplays,
+    sharedLabelEntityId: sharedLabel.id,
+    sharedLabelText: 'WEDSharer',
     translation: entity.metadata[translationIndex]
   }))
-  bot.quit('e2e complete')
+  sharer.quit('e2e complete')
+  viewer.quit('e2e complete')
 } catch (error) {
   fatal(error)
 }

--- a/integration/mineflayer/test.mjs
+++ b/integration/mineflayer/test.mjs
@@ -1,0 +1,139 @@
+import mineflayer from 'mineflayer'
+
+const port = Number(process.env.WED_E2E_PORT ?? 25579)
+const timeoutMs = 45_000
+
+function waitForMessage(bot, expected) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      bot.removeListener('messagestr', listener)
+      reject(new Error(`Timed out waiting for message: ${expected}`))
+    }, timeoutMs)
+    const listener = (message) => {
+      if (!message.includes(expected)) return
+      clearTimeout(timeout)
+      bot.removeListener('messagestr', listener)
+      resolve(message)
+    }
+    bot.on('messagestr', listener)
+  })
+}
+
+function waitForTextDisplay(bot) {
+  return new Promise((resolve, reject) => {
+    const current = Object.values(bot.entities).find(entity => entity.name === 'text_display')
+    if (current) {
+      resolve(current)
+      return
+    }
+    const timeout = setTimeout(() => {
+      bot.removeListener('entitySpawn', listener)
+      reject(new Error('Timed out waiting for a WorldEditDisplay text_display entity'))
+    }, timeoutMs)
+    const listener = (entity) => {
+      if (entity.name !== 'text_display') return
+      clearTimeout(timeout)
+      bot.removeListener('entitySpawn', listener)
+      resolve(entity)
+    }
+    bot.on('entitySpawn', listener)
+  })
+}
+
+function waitForMetadata(bot, entity, predicate, description) {
+  return new Promise((resolve, reject) => {
+    if (predicate(entity)) {
+      resolve(entity)
+      return
+    }
+    const timeout = setTimeout(() => {
+      bot.removeListener('entityUpdate', listener)
+      reject(new Error(`Timed out waiting for ${description}`))
+    }, timeoutMs)
+    const listener = (updated) => {
+      if (updated.id !== entity.id || !predicate(updated)) return
+      clearTimeout(timeout)
+      bot.removeListener('entityUpdate', listener)
+      resolve(updated)
+    }
+    bot.on('entityUpdate', listener)
+  })
+}
+
+const bot = mineflayer.createBot({
+  host: '127.0.0.1',
+  port,
+  username: 'WEDClient',
+  version: '1.21.11',
+  auth: 'offline'
+})
+
+const fatal = (error) => {
+  console.error(error)
+  process.exitCode = 1
+  bot.quit('e2e failed')
+}
+
+try {
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => fail(new Error('Timed out waiting for Mineflayer spawn')), timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      bot.removeListener('spawn', spawned)
+      bot.removeListener('error', fail)
+      bot.removeListener('kicked', kicked)
+    }
+    const spawned = () => {
+      cleanup()
+      resolve()
+    }
+    const fail = (error) => {
+      cleanup()
+      reject(error)
+    }
+    const kicked = (reason) => fail(new Error(`Mineflayer was kicked: ${reason}`))
+    bot.once('spawn', spawned)
+    bot.once('error', fail)
+    bot.once('kicked', kicked)
+  })
+
+  bot.once('error', fatal)
+  bot.once('kicked', reason => fatal(new Error(`Mineflayer was kicked: ${reason}`)))
+
+  const readyMessage = waitForMessage(bot, 'WED_READY:')
+  bot.chat('/wedtest')
+  const ready = await readyMessage
+  const entityCount = Number(ready.substring(ready.indexOf('WED_READY:') + 'WED_READY:'.length).trim())
+  if (!Number.isInteger(entityCount) || entityCount <= 0) {
+    throw new Error(`WorldEditDisplay reported an invalid entity count: ${ready}`)
+  }
+
+  const entity = await waitForTextDisplay(bot)
+  const translationIndex = bot.registry.entitiesByName.text_display.metadataKeys.indexOf('translation')
+  if (translationIndex < 0) {
+    throw new Error('Mineflayer registry does not expose Text Display translation metadata')
+  }
+  await waitForMetadata(
+    bot,
+    entity,
+    current => Number.isFinite(current.metadata[translationIndex]?.x),
+    'WorldEditDisplay Text Display translation metadata'
+  )
+
+  const visibleTextDisplays = Object.values(bot.entities)
+    .filter(current => current.name === 'text_display')
+    .length
+  if (visibleTextDisplays <= 0) {
+    throw new Error('WorldEditDisplay did not leave any visible Text Display entities')
+  }
+
+  console.log(JSON.stringify({
+    managerInitialized: true,
+    rendererEntities: entityCount,
+    visibleTextDisplays,
+    translation: entity.metadata[translationIndex]
+  }))
+  bot.quit('e2e complete')
+} catch (error) {
+  fatal(error)
+}

--- a/integration/paper-plugin/pom.xml
+++ b/integration/paper-plugin/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.twme.worldeditdisplay</groupId>
+    <artifactId>worldeditdisplay-integration</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>codemc-releases</id>
+            <url>https://repo.codemc.io/repository/maven-releases/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.retrooper</groupId>
+            <artifactId>packetevents-spigot</artifactId>
+            <version>2.13.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>WorldEditDisplayIntegration</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
+++ b/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
@@ -1,0 +1,84 @@
+package io.github.twme.worldeditdisplay.integration;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPluginMessage;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+/** Paper fixture that drives WorldEditDisplay through its WorldEdit CUI input. */
+public final class WorldEditDisplayIntegrationPlugin extends JavaPlugin {
+    private static final String CUI_CHANNEL = "worldedit:cui";
+
+    @Override
+    public void onEnable() {
+        // WorldEditDisplay is a hard dependency, so its PacketEvents listeners are ready first.
+    }
+
+    @Override
+    public boolean onCommand(
+            @NotNull CommandSender sender,
+            @NotNull Command command,
+            @NotNull String label,
+            @NotNull String[] arguments
+    ) {
+        if (!(sender instanceof Player player)) {
+            return true;
+        }
+
+        Plugin worldEditDisplay = getServer().getPluginManager().getPlugin("WorldEditDisplay");
+        if (worldEditDisplay == null || !worldEditDisplay.isEnabled()) {
+            player.sendMessage("WED_ERROR:plugin unavailable");
+            return true;
+        }
+
+        try {
+            Method managerGetter = worldEditDisplay.getClass().getMethod("getVirtualEntityManager");
+            Method factoryGetter = worldEditDisplay.getClass().getMethod("getPacketShapeFactory");
+            if (managerGetter.invoke(worldEditDisplay) == null || factoryGetter.invoke(worldEditDisplay) == null) {
+                player.sendMessage("WED_ERROR:VirtualEntities lifecycle unavailable");
+                return true;
+            }
+        } catch (ReflectiveOperationException exception) {
+            getLogger().severe("Unable to inspect the WorldEditDisplay VirtualEntities lifecycle: " + exception);
+            player.sendMessage("WED_ERROR:VirtualEntities lifecycle inspection failed");
+            return true;
+        }
+
+        int x = player.getLocation().getBlockX() + 2;
+        int y = player.getLocation().getBlockY();
+        int z = player.getLocation().getBlockZ() + 2;
+        sendCui(player, "s|cuboid");
+        sendCui(player, "p|0|" + x + "|" + y + "|" + z + "|27");
+        sendCui(player, "p|1|" + (x + 2) + "|" + (y + 2) + "|" + (z + 2) + "|27");
+
+        getServer().getScheduler().runTaskLater(this, () -> reportEntityCount(player, worldEditDisplay), 20L);
+        return true;
+    }
+
+    private void sendCui(Player player, String message) {
+        PacketEvents.getAPI().getPlayerManager().sendPacket(
+                player,
+                new WrapperPlayServerPluginMessage(CUI_CHANNEL, message.getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    private void reportEntityCount(Player player, Plugin worldEditDisplay) {
+        try {
+            Object renderManager = worldEditDisplay.getClass().getMethod("getRenderManager").invoke(worldEditDisplay);
+            int entityCount = (int) renderManager.getClass()
+                    .getMethod("getPlayerEntityCount", java.util.UUID.class)
+                    .invoke(renderManager, player.getUniqueId());
+            player.sendMessage("WED_READY:" + entityCount);
+        } catch (ReflectiveOperationException exception) {
+            getLogger().severe("Unable to inspect the WorldEditDisplay renderer: " + exception);
+            player.sendMessage("WED_ERROR:renderer inspection failed");
+        }
+    }
+}

--- a/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
+++ b/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
@@ -54,12 +54,15 @@ public final class WorldEditDisplayIntegrationPlugin extends JavaPlugin {
         int x = player.getLocation().getBlockX() + 2;
         int y = player.getLocation().getBlockY();
         int z = player.getLocation().getBlockZ() + 2;
+        String secondPoint = "p|1|" + (x + 2) + "|" + (y + 2) + "|" + (z + 2) + "|27";
         sendCui(player, "s|cuboid");
         sendCui(player, "p|0|" + x + "|" + y + "|" + z + "|27");
-        sendCui(player, "p|1|" + (x + 2) + "|" + (y + 2) + "|" + (z + 2) + "|27");
+        sendCui(player, secondPoint);
 
         getServer().getScheduler().runTaskLater(this, () -> {
-            sendCui(player, "u|0");
+            // Re-send an unchanged point after the first render has settled. This
+            // forces a second retained render pass through the real CUI path.
+            sendCui(player, secondPoint);
             getServer().getScheduler().runTaskLater(
                     this,
                     () -> reportRendererState(player, worldEditDisplay),

--- a/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
+++ b/integration/paper-plugin/src/main/java/io/github/twme/worldeditdisplay/integration/WorldEditDisplayIntegrationPlugin.java
@@ -58,7 +58,14 @@ public final class WorldEditDisplayIntegrationPlugin extends JavaPlugin {
         sendCui(player, "p|0|" + x + "|" + y + "|" + z + "|27");
         sendCui(player, "p|1|" + (x + 2) + "|" + (y + 2) + "|" + (z + 2) + "|27");
 
-        getServer().getScheduler().runTaskLater(this, () -> reportEntityCount(player, worldEditDisplay), 20L);
+        getServer().getScheduler().runTaskLater(this, () -> {
+            sendCui(player, "u|0");
+            getServer().getScheduler().runTaskLater(
+                    this,
+                    () -> reportRendererState(player, worldEditDisplay),
+                    20L
+            );
+        }, 20L);
         return true;
     }
 
@@ -69,13 +76,30 @@ public final class WorldEditDisplayIntegrationPlugin extends JavaPlugin {
         );
     }
 
-    private void reportEntityCount(Player player, Plugin worldEditDisplay) {
+    private void reportRendererState(Player player, Plugin worldEditDisplay) {
         try {
             Object renderManager = worldEditDisplay.getClass().getMethod("getRenderManager").invoke(worldEditDisplay);
             int entityCount = (int) renderManager.getClass()
                     .getMethod("getPlayerEntityCount", java.util.UUID.class)
                     .invoke(renderManager, player.getUniqueId());
-            player.sendMessage("WED_READY:" + entityCount);
+            int retainedLineCount = (int) renderManager.getClass()
+                    .getMethod("getPlayerRetainedLineCount", java.util.UUID.class)
+                    .invoke(renderManager, player.getUniqueId());
+            int retainedLineEntityCount = (int) renderManager.getClass()
+                    .getMethod("getPlayerRetainedLineEntityCount", java.util.UUID.class)
+                    .invoke(renderManager, player.getUniqueId());
+            Object retainedLineStats = renderManager.getClass()
+                    .getMethod("getPlayerRetainedLineStats", java.util.UUID.class)
+                    .invoke(renderManager, player.getUniqueId());
+            int reusedLines = (int) retainedLineStats.getClass().getMethod("reusedLines").invoke(retainedLineStats);
+            int spawnedLines = (int) retainedLineStats.getClass().getMethod("spawnedLines").invoke(retainedLineStats);
+            int removedLines = (int) retainedLineStats.getClass().getMethod("removedLines").invoke(retainedLineStats);
+            player.sendMessage("WED_READY:" + entityCount
+                    + ":" + retainedLineCount
+                    + ":" + retainedLineEntityCount
+                    + ":" + reusedLines
+                    + ":" + spawnedLines
+                    + ":" + removedLines);
         } catch (ReflectiveOperationException exception) {
             getLogger().severe("Unable to inspect the WorldEditDisplay renderer: " + exception);
             player.sendMessage("WED_ERROR:renderer inspection failed");

--- a/integration/paper-plugin/src/main/resources/plugin.yml
+++ b/integration/paper-plugin/src/main/resources/plugin.yml
@@ -1,0 +1,10 @@
+name: WorldEditDisplayIntegration
+version: '1.0.0'
+main: io.github.twme.worldeditdisplay.integration.WorldEditDisplayIntegrationPlugin
+api-version: '1.21'
+depend:
+  - packetevents
+  - WorldEditDisplay
+commands:
+  wedtest:
+    description: Sends a cuboid WorldEdit CUI selection for integration testing.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.twme</groupId>
   <artifactId>WorldEditDisplay</artifactId>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <packaging>jar</packaging>
 
   <name>WorldEditDisplay</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>WorldEditDisplay</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <platform>paper</platform>
   </properties>
@@ -26,8 +26,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,13 @@
     <dependency>
       <groupId>com.github.twme-ai.TextDisplayShapes</groupId>
       <artifactId>textdisplayshape-packet</artifactId>
-      <version>v3.0.0</version>
+      <version>c0ad5ded36381101c5175ef98315a4ab00b96ce8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.twme-ai</groupId>
       <artifactId>VirtualEntities</artifactId>
-      <version>v0.7.0</version>
+      <version>v0.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,16 @@
       <url>https://repo.codemc.io/repository/maven-snapshots/</url>
     </repository>
     <repository>
+      <id>twme-releases</id>
+      <url>https://repo.twme.dev/releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>jitpack</id>
       <url>https://jitpack.io</url>
       <releases>
@@ -129,9 +139,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.twme-ai.TextDisplayShapes</groupId>
+      <groupId>dev.twme</groupId>
       <artifactId>textdisplayshape-packet</artifactId>
-      <version>f6ef63969c836dfe3e14b0a3f6ccbdeadc1970b2</version>
+      <version>3.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>com.github.twme-ai.TextDisplayShapes</groupId>
       <artifactId>textdisplayshape-packet</artifactId>
-      <version>c0ad5ded36381101c5175ef98315a4ab00b96ce8</version>
+      <version>f6ef63969c836dfe3e14b0a3f6ccbdeadc1970b2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,9 @@
             <configuration>
               <filters>
                 <!--
-                  Share core adventure-api classes from packetevents' classloader to
-                  avoid ClassCastException when EntityLib passes Component objects to
-                  packetevents APIs (e.g. EntityDataType.write()).
-                  Only serializer/flattener/builder classes are shaded into WED.
-                  Both use adventure 4.x so there is no API mismatch.
-                  Paper profile: adventure-api is "provided" so this filter is a no-op.
+                  Share core adventure-api classes from PacketEvents' classloader so
+                  VirtualEntities and the server use one Component type. Only serializer,
+                  flattener, and builder classes are shaded for the Spigot profile.
                 -->
                 <filter>
                   <artifact>net.kyori:adventure-api</artifact>
@@ -63,25 +60,11 @@
                     <include>net/kyori/adventure/builder/**</include>
                   </includes>
                 </filter>
-                <!--
-                  textdisplayshape-packet bundles its own EntityLib classes.
-                  Exclude them so our direct (fixed) EntityLib dependency takes precedence.
-                -->
-                <filter>
-                  <artifact>dev.twme:textdisplayshape-packet</artifact>
-                  <excludes>
-                    <exclude>me/tofaa/entitylib/**</exclude>
-                  </excludes>
-                </filter>
               </filters>
               <relocations>
                 <relocation>
                   <pattern>dev.twme.textdisplayshape</pattern>
                   <shadedPattern>dev.twme.worldeditdisplay.lib.textdisplayshape</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>me.tofaa.entitylib</pattern>
-                  <shadedPattern>dev.twme.worldeditdisplay.lib.entitylib</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.bstats</pattern>
@@ -119,9 +102,14 @@
       <url>https://repo.codemc.io/repository/maven-snapshots/</url>
     </repository>
     <repository>
-      <id>twme-repo-snapshots</id>
-      <name>TWME Repository</name>
-      <url>https://repo.twme.dev/snapshots</url>
+      <id>jitpack</id>
+      <url>https://jitpack.io</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
     <repository>
       <id>opencollab-snapshot</id>
@@ -137,19 +125,19 @@
     <dependency>
       <groupId>com.github.retrooper</groupId>
       <artifactId>packetevents-spigot</artifactId>
-      <version>2.12.2</version>
+      <version>2.13.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>dev.twme</groupId>
+      <groupId>com.github.twme-ai.TextDisplayShapes</groupId>
       <artifactId>textdisplayshape-packet</artifactId>
-      <version>2.0.2-SNAPSHOT</version>
+      <version>v3.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.github.tofaa2</groupId>
-      <artifactId>spigot</artifactId>
-      <version>3.3.4+b54a52a-SNAPSHOT</version>
+      <groupId>com.github.twme-ai</groupId>
+      <artifactId>VirtualEntities</artifactId>
+      <version>v0.7.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -189,7 +177,7 @@
         <dependency>
           <groupId>io.papermc.paper</groupId>
           <artifactId>paper-api</artifactId>
-          <version>1.21.10-R0.1-SNAPSHOT</version>
+          <version>1.21.11-R0.1-SNAPSHOT</version>
           <scope>provided</scope>
         </dependency>
         <!-- For compilation only; available at runtime via Paper server -->
@@ -219,7 +207,7 @@
              shade all adventure deps to make the jar self-contained.
              Core adventure-api classes (Component, etc.) are filtered out so they
              are shared from packetevents' classloader, preventing ClassCastException
-             when EntityLib passes Component objects to packetevents APIs.
+             when VirtualEntities passes Component objects to PacketEvents APIs.
              Both WED and packetevents use adventure 4.x → binary compatible.
              adventure-key, examination-api/string are provided by packetevents. -->
         <dependency>

--- a/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
+++ b/src/main/java/dev/twme/worldeditdisplay/WorldEditDisplay.java
@@ -24,12 +24,12 @@ import dev.twme.worldeditdisplay.listener.PlayerLocaleChangeListener;
 import dev.twme.worldeditdisplay.listener.PlayerQuitListener;
 import dev.twme.worldeditdisplay.share.ShareManager;
 import dev.twme.worldeditdisplay.util.MessageUtil;
+import dev.twme.textdisplayshape.packet.PacketShapeFactory;
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 import io.github.retrooper.packetevents.util.folia.TaskWrapper;
-import me.tofaa.entitylib.APIConfig;
-import me.tofaa.entitylib.EntityLib;
-import me.tofaa.entitylib.spigot.SpigotEntityLibPlatform;
+import io.github.twme.virtualentities.VirtualEntities;
+import io.github.twme.virtualentities.VirtualEntityManager;
 
 public final class WorldEditDisplay extends JavaPlugin {
     private static WorldEditDisplay plugin;
@@ -38,6 +38,8 @@ public final class WorldEditDisplay extends JavaPlugin {
     private PlayerSettingsManager playerSettingsManager;
     private LanguageManager languageManager;
     private ShareManager shareManager;
+    private VirtualEntityManager virtualEntityManager;
+    private PacketShapeFactory packetShapeFactory;
     private final Set<UUID> viewAllPlayers = ConcurrentHashMap.newKeySet();
 
     // Packet listener references (kept for clean unregistration on disable)
@@ -71,15 +73,13 @@ public final class WorldEditDisplay extends JavaPlugin {
 
         PacketEvents.getAPI().init();
 
+        virtualEntityManager = VirtualEntities.create();
+        packetShapeFactory = new PacketShapeFactory(virtualEntityManager);
+
         inboundListenerInstance = new InboundPacketListener();
         inboundPacketListener = PacketEvents.getAPI().getEventManager().registerListener(inboundListenerInstance, PacketListenerPriority.NORMAL);
         outboundListenerInstance = new OutboundPacketListener();
         outboundPacketListener = PacketEvents.getAPI().getEventManager().registerListener(outboundListenerInstance, PacketListenerPriority.NORMAL);
-
-        SpigotEntityLibPlatform platform = new SpigotEntityLibPlatform(this);
-        APIConfig settings = new APIConfig(PacketEvents.getAPI())
-                .usePlatformLogger();
-        EntityLib.init(platform, settings);
 
         // Load default configuration
         saveDefaultConfig();
@@ -154,6 +154,24 @@ public final class WorldEditDisplay extends JavaPlugin {
             playerSettingsSaveTask = null;
         }
 
+        // Stop packet-driven state changes before render and entity cleanup.
+        if (inboundListenerInstance != null) {
+            inboundListenerInstance.deactivate();
+            inboundListenerInstance = null;
+        }
+        if (outboundListenerInstance != null) {
+            outboundListenerInstance.deactivate();
+            outboundListenerInstance = null;
+        }
+        if (inboundPacketListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(inboundPacketListener);
+            inboundPacketListener = null;
+        }
+        if (outboundPacketListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(outboundPacketListener);
+            outboundPacketListener = null;
+        }
+
         // Save share data
         if (shareManager != null) {
             shareManager.save();
@@ -168,26 +186,10 @@ public final class WorldEditDisplay extends JavaPlugin {
         if (renderManager != null) {
             renderManager.shutdown();
         }
-
-        // STEP 1 — Deactivate listener flags FIRST, so any in-flight
-        // Netty dispatch that hasn't yet entered the listener method
-        // will bail out at the `!active` guard before triggering any
-        // lazy plugin class loading.
-        if (inboundListenerInstance != null) {
-            inboundListenerInstance.deactivate();
-        }
-        if (outboundListenerInstance != null) {
-            outboundListenerInstance.deactivate();
-        }
-
-        // STEP 2 — Then unregister from PacketEvents (future dispatches).
-        if (inboundPacketListener != null) {
-            PacketEvents.getAPI().getEventManager().unregisterListener(inboundPacketListener);
-            inboundPacketListener = null;
-        }
-        if (outboundPacketListener != null) {
-            PacketEvents.getAPI().getEventManager().unregisterListener(outboundPacketListener);
-            outboundPacketListener = null;
+        if (virtualEntityManager != null) {
+            virtualEntityManager.close();
+            virtualEntityManager = null;
+            packetShapeFactory = null;
         }
 
         getLogger().info("WorldEditDisplay disabled");
@@ -215,6 +217,20 @@ public final class WorldEditDisplay extends JavaPlugin {
 
     public ShareManager getShareManager() {
         return shareManager;
+    }
+
+    public VirtualEntityManager getVirtualEntityManager() {
+        if (virtualEntityManager == null) {
+            throw new IllegalStateException("Virtual entity manager is not available");
+        }
+        return virtualEntityManager;
+    }
+
+    public PacketShapeFactory getPacketShapeFactory() {
+        if (packetShapeFactory == null) {
+            throw new IllegalStateException("Packet shape factory is not available");
+        }
+        return packetShapeFactory;
     }
 
     public Set<UUID> getViewAllPlayers() {

--- a/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
@@ -14,7 +14,9 @@ import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.Vector3f;
 
 import dev.twme.worldeditdisplay.WorldEditDisplay;
@@ -47,9 +49,9 @@ import dev.twme.worldeditdisplay.util.MessageUtil;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
 import io.github.retrooper.packetevents.util.folia.FoliaScheduler;
 import io.github.retrooper.packetevents.util.folia.TaskWrapper;
-import me.tofaa.entitylib.meta.display.AbstractDisplayMeta;
-import me.tofaa.entitylib.meta.display.TextDisplayMeta;
-import me.tofaa.entitylib.wrapper.WrapperEntity;
+import io.github.twme.virtualentities.VirtualEntity;
+import io.github.twme.virtualentities.metadata.EntityMetadataFlags;
+import io.github.twme.virtualentities.metadata.GeneratedEntityMetadataKeys;
 
 /**
  * keeps track of player renderers
@@ -64,7 +66,7 @@ public class RenderManager {
     /** viewer → (sharer → renderer): renderers for other players' shared selections */
     private final Map<UUID, Map<UUID, RegionRenderer>> sharedRenderers;
     /** viewer → (sharer → label entity): name-tag labels shown above shared selections */
-    private final Map<UUID, Map<UUID, WrapperEntity>> labelEntities;
+    private final Map<UUID, Map<UUID, VirtualEntity>> labelEntities;
     /** sharer → colour: stable shared-selection colour assignments across all viewers */
     private final Map<UUID, Color> sharedColors;
     /**
@@ -98,6 +100,7 @@ public class RenderManager {
     private static final float SHARED_MIN_HUE_DISTANCE = 0.12f;
     private static final float SHARED_HUE_STEP = 0.61803398875f;
     private static final int SHARED_COLOR_ATTEMPTS = 12;
+    private static final byte BILLBOARD_CENTER = 3;
 
     private TaskWrapper rebaseTask;
 
@@ -325,7 +328,7 @@ public class RenderManager {
                                                 Map<UUID, RegionRenderer> viewerRenderers,
                                                 Set<UUID> visibleSharers) {
         Set<UUID> referencedSharers = new HashSet<>(viewerRenderers.keySet());
-        Map<UUID, WrapperEntity> viewerLabels = labelEntities.get(viewerId);
+        Map<UUID, VirtualEntity> viewerLabels = labelEntities.get(viewerId);
         if (viewerLabels != null) referencedSharers.addAll(viewerLabels.keySet());
 
         for (UUID sharerId : referencedSharers) {
@@ -338,7 +341,7 @@ public class RenderManager {
                                                     Map<UUID, ParticleRenderer> viewerRenderers,
                                                     Set<UUID> visibleSharers) {
         Set<UUID> referencedSharers = new HashSet<>(viewerRenderers.keySet());
-        Map<UUID, WrapperEntity> viewerLabels = labelEntities.get(viewerId);
+        Map<UUID, VirtualEntity> viewerLabels = labelEntities.get(viewerId);
         if (viewerLabels != null) referencedSharers.addAll(viewerLabels.keySet());
 
         for (UUID sharerId : referencedSharers) {
@@ -644,7 +647,7 @@ public class RenderManager {
         return sharedColors;
     }
 
-    Map<UUID, Map<UUID, WrapperEntity>> getLabelEntities() {
+    Map<UUID, Map<UUID, VirtualEntity>> getLabelEntities() {
         return labelEntities;
     }
 
@@ -663,7 +666,7 @@ public class RenderManager {
         for (Map<UUID, ParticleRenderer> viewerRenderers : sharedParticleRenderers.values()) {
             if (viewerRenderers.containsKey(sharerId)) return true;
         }
-        for (Map<UUID, WrapperEntity> viewerLabels : labelEntities.values()) {
+        for (Map<UUID, VirtualEntity> viewerLabels : labelEntities.values()) {
             if (viewerLabels.containsKey(sharerId)) return true;
         }
         return false;
@@ -774,53 +777,59 @@ public class RenderManager {
             nameChanged = true;
         }
 
-        Map<UUID, WrapperEntity> viewerLabels =
+        Map<UUID, VirtualEntity> viewerLabels =
                 labelEntities.computeIfAbsent(viewerId, k -> new ConcurrentHashMap<>());
-        WrapperEntity existingLabel = viewerLabels.get(sharerId);
+        VirtualEntity existingLabel = viewerLabels.get(sharerId);
 
         if (existingLabel != null) {
             // Only send a metadata packet when the sharer's name was rebuilt this frame.
-            if (nameChanged && existingLabel.getEntityMeta() instanceof TextDisplayMeta meta) {
-                meta.setText(nameText);
+            if (nameChanged) {
+                existingLabel.metadata().set(GeneratedEntityMetadataKeys.TextDisplay.TEXT, nameText);
+                existingLabel.syncMetadata();
             }
             existingLabel.teleport(SpigotConversionUtil.fromBukkitLocation(labelLoc));
             return;
         }
 
-        WrapperEntity label = new WrapperEntity(EntityTypes.TEXT_DISPLAY);
-        label.spawn(SpigotConversionUtil.fromBukkitLocation(labelLoc));
-        if (label.getEntityMeta() instanceof TextDisplayMeta meta) {
-            // Derive a dark, semi-opaque background from the sharer's shared colour
-            int bgColor = (0xC0 << 24)
-                    | ((int) (sharedColor.getRed()   * 0.25) << 16)
-                    | ((int) (sharedColor.getGreen() * 0.25) <<  8)
-                    |  (int) (sharedColor.getBlue()  * 0.25);
-            meta.setText(nameText);
-            meta.setBillboardConstraints(AbstractDisplayMeta.BillboardConstraints.CENTER);
-            meta.setScale(new Vector3f(2.0f, 2.0f, 2.0f));
-            meta.setSeeThrough(true);
-            meta.setViewRange(64.0f);
-            meta.setBrightnessOverride(15 << 4 | 15 << 20);
-            meta.setBackgroundColor(bgColor);
+        User viewerUser = PacketEvents.getAPI().getPlayerManager().getUser(viewer);
+        if (viewerUser == null) {
+            return;
         }
-        label.addViewer(viewerId);
+        // Derive a dark, semi-opaque background from the sharer's shared colour.
+        int backgroundColor = (0xC0 << 24)
+                | ((int) (sharedColor.getRed() * 0.25) << 16)
+                | ((int) (sharedColor.getGreen() * 0.25) << 8)
+                | (int) (sharedColor.getBlue() * 0.25);
+        VirtualEntity label = plugin.getVirtualEntityManager()
+                .entity(EntityTypes.TEXT_DISPLAY)
+                .metadata()
+                .build();
+        label.metadata()
+                .set(GeneratedEntityMetadataKeys.TextDisplay.TEXT, nameText)
+                .set(GeneratedEntityMetadataKeys.TextDisplay.BACKGROUND_COLOR, backgroundColor)
+                .setFlag(EntityMetadataFlags.TextDisplay.SEE_THROUGH, true)
+                .set(GeneratedEntityMetadataKeys.Display.BILLBOARD_RENDER_CONSTRAINTS, BILLBOARD_CENTER)
+                .set(GeneratedEntityMetadataKeys.Display.SCALE, new Vector3f(2.0f, 2.0f, 2.0f))
+                .set(GeneratedEntityMetadataKeys.Display.VIEW_RANGE, 64.0f)
+                .set(GeneratedEntityMetadataKeys.Display.BRIGHTNESS_OVERRIDE, 15 << 4 | 15 << 20);
+        label.addViewer(viewerUser).spawn(SpigotConversionUtil.fromBukkitLocation(labelLoc));
         viewerLabels.put(sharerId, label);
     }
 
     /** Remove the label entity a specific viewer has for a specific sharer. */
     private void clearSharedLabel(UUID viewerId, UUID sharerId) {
-        Map<UUID, WrapperEntity> viewerLabels = labelEntities.get(viewerId);
+        Map<UUID, VirtualEntity> viewerLabels = labelEntities.get(viewerId);
         if (viewerLabels == null) return;
-        WrapperEntity label = viewerLabels.remove(sharerId);
+        VirtualEntity label = viewerLabels.remove(sharerId);
         if (label != null) label.remove();
         if (viewerLabels.isEmpty()) labelEntities.remove(viewerId);
     }
 
     /** Remove all label entities for a specific viewer. */
     public void clearSharedLabels(UUID viewerId) {
-        Map<UUID, WrapperEntity> viewerLabels = labelEntities.remove(viewerId);
+        Map<UUID, VirtualEntity> viewerLabels = labelEntities.remove(viewerId);
         if (viewerLabels != null) {
-            for (WrapperEntity label : viewerLabels.values()) {
+            for (VirtualEntity label : viewerLabels.values()) {
                 if (label != null) label.remove();
             }
             viewerLabels.clear();
@@ -846,7 +855,7 @@ public class RenderManager {
             particleMap.clear();
         }
 
-        Map<UUID, WrapperEntity> viewerLabels = labelEntities.get(viewerId);
+        Map<UUID, VirtualEntity> viewerLabels = labelEntities.get(viewerId);
         if (viewerLabels != null) sharerIds.addAll(viewerLabels.keySet());
         clearSharedLabels(viewerId);
 
@@ -1215,7 +1224,7 @@ public class RenderManager {
         sharedRenderers.clear();
         sharedColors.clear();
 
-        labelEntities.values().forEach(m -> m.values().forEach(WrapperEntity::remove));
+        labelEntities.values().forEach(m -> m.values().forEach(VirtualEntity::remove));
         labelEntities.clear();
 
         // Particle fallback renderers

--- a/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/RenderManager.java
@@ -812,7 +812,9 @@ public class RenderManager {
                 .set(GeneratedEntityMetadataKeys.Display.SCALE, new Vector3f(2.0f, 2.0f, 2.0f))
                 .set(GeneratedEntityMetadataKeys.Display.VIEW_RANGE, 64.0f)
                 .set(GeneratedEntityMetadataKeys.Display.BRIGHTNESS_OVERRIDE, 15 << 4 | 15 << 20);
-        label.addViewer(viewerUser).spawn(SpigotConversionUtil.fromBukkitLocation(labelLoc));
+        plugin.getPacketShapeFactory()
+                .addViewer(label, viewerUser)
+                .spawn(SpigotConversionUtil.fromBukkitLocation(labelLoc));
         viewerLabels.put(sharerId, label);
     }
 

--- a/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
@@ -15,7 +15,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.joml.Vector3f;
 
-import dev.twme.textdisplayshape.packet.PacketShapeFactory;
 import dev.twme.textdisplayshape.shape.Shape;
 import dev.twme.worldeditdisplay.WorldEditDisplay;
 import dev.twme.worldeditdisplay.config.PlayerRenderSettings;
@@ -37,8 +36,6 @@ public abstract class RegionRenderer<T extends Region> {
     protected final Player player;
     protected final UUID playerUUID;
     protected final PlayerRenderSettings settings;
-    private final PacketShapeFactory shapeFactory;
-
     // pool of shapes
     protected final List<Shape> shapes;
     private final Map<LineKey, Shape> retainedLineShapes;
@@ -62,7 +59,6 @@ public abstract class RegionRenderer<T extends Region> {
         this.player = player;
         this.playerUUID = player.getUniqueId();
         this.settings = settings;
-        this.shapeFactory = new PacketShapeFactory();
         this.shapes = new ArrayList<>();
         this.retainedLineShapes = new HashMap<>();
         this.retainedLineShapeSet = new HashSet<>();
@@ -241,7 +237,7 @@ public abstract class RegionRenderer<T extends Region> {
 
     private Shape createLineShape(Line line, Color color, float thickness) {
         Location origin = getOrigin();
-        Shape shape = shapeFactory
+        Shape shape = plugin.getPacketShapeFactory()
                 .line(origin, line.start(), line.end(), thickness)
             .rootAnchor(true)
                 .color(color)
@@ -319,7 +315,7 @@ public abstract class RegionRenderer<T extends Region> {
      */
     protected void renderParallelogram(Vector3f p1, Vector3f p2, Vector3f p3, Color color) {
         Location origin = getOrigin();
-        Shape shape = shapeFactory
+        Shape shape = plugin.getPacketShapeFactory()
                 .parallelogram(origin, p1, p2, p3)
             .rootAnchor(true)
                 .color(color)
@@ -338,7 +334,7 @@ public abstract class RegionRenderer<T extends Region> {
      */
     protected void renderTriangle(Vector3f p1, Vector3f p2, Vector3f p3, Color color) {
         Location origin = getOrigin();
-        Shape shape = shapeFactory
+        Shape shape = plugin.getPacketShapeFactory()
                 .triangle(origin, p1, p2, p3)
             .rootAnchor(true)
                 .color(color)
@@ -418,7 +414,6 @@ public abstract class RegionRenderer<T extends Region> {
     }
 
     protected record Line(Vector3f start, Vector3f end){};
-
     public record RetainedLineStats(int reusedLines, int spawnedLines, int removedLines, int removedTransientShapes) {
         public static RetainedLineStats empty() {
             return new RetainedLineStats(0, 0, 0, 0);

--- a/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
+++ b/src/main/java/dev/twme/worldeditdisplay/display/renderer/RegionRenderer.java
@@ -55,6 +55,7 @@ public abstract class RegionRenderer<T extends Region> {
     private Location renderOrigin;
 
     private static final double REBASE_DISTANCE_SQUARED = 80.0 * 80.0;
+    private static final float MIN_LINE_LENGTH_SQUARED = 1.0e-6f;
 
     public RegionRenderer(WorldEditDisplay plugin, Player player, PlayerRenderSettings settings) {
         this.plugin = plugin;
@@ -206,6 +207,8 @@ public abstract class RegionRenderer<T extends Region> {
      * Render a line using TextDisplayShapes
      */
     protected void renderLine(Line line, Color color, float thickness) {
+        if (!isRenderableLine(line)) return;
+
         if (retainedLinePassKeys != null) {
             LineKey key = LineKey.of(line, color, thickness, isSeeThrough());
             retainedLinePassKeys.add(key);
@@ -225,6 +228,15 @@ public abstract class RegionRenderer<T extends Region> {
 
         Shape shape = createLineShape(line, color, thickness);
         shapes.add(shape);
+    }
+
+    static boolean isRenderableLine(Line line) {
+        return line != null
+                && line.start() != null
+                && line.end() != null
+                && line.start().isFinite()
+                && line.end().isFinite()
+                && line.start().distanceSquared(line.end()) >= MIN_LINE_LENGTH_SQUARED;
     }
 
     private Shape createLineShape(Line line, Color color, float thickness) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: WorldEditDisplay
 version: '${project.version}'
 main: dev.twme.worldeditdisplay.WorldEditDisplay
-api-version: '1.20'
+api-version: '1.19'
 folia-supported: true
 authors: [ TWME-TW ]
 depend:

--- a/src/test/java/dev/twme/worldeditdisplay/PluginDescriptorTest.java
+++ b/src/test/java/dev/twme/worldeditdisplay/PluginDescriptorTest.java
@@ -1,0 +1,23 @@
+package dev.twme.worldeditdisplay;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+class PluginDescriptorTest {
+
+    @Test
+    void supportsPaper119() throws IOException {
+        try (InputStream stream = getClass().getResourceAsStream("/plugin.yml")) {
+            assertNotNull(stream);
+            Map<String, Object> descriptor = new Yaml().load(stream);
+            assertEquals("1.19", descriptor.get("api-version"));
+        }
+    }
+}

--- a/src/test/java/dev/twme/worldeditdisplay/display/RenderManagerSharedCacheTest.java
+++ b/src/test/java/dev/twme/worldeditdisplay/display/RenderManagerSharedCacheTest.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 import org.bukkit.Color;
 import org.junit.jupiter.api.Test;
 
+import io.github.twme.virtualentities.VirtualEntity;
+
 class RenderManagerSharedCacheTest {
 
     @Test
@@ -32,7 +34,7 @@ class RenderManagerSharedCacheTest {
         UUID sharerId = UUID.randomUUID();
 
         renderManager.getSharedColors().put(sharerId, Color.RED);
-        Map<UUID, me.tofaa.entitylib.wrapper.WrapperEntity> viewerLabels = new java.util.HashMap<>();
+        Map<UUID, VirtualEntity> viewerLabels = new java.util.HashMap<>();
         viewerLabels.put(sharerId, null);
         renderManager.getLabelEntities().put(viewerId, viewerLabels);
 
@@ -49,7 +51,7 @@ class RenderManagerSharedCacheTest {
 
         renderManager.getSharedColors().put(sharerId, Color.RED);
         renderManager.getLabelComponentNames().put(sharerId, "Sharer");
-        Map<UUID, me.tofaa.entitylib.wrapper.WrapperEntity> viewerLabels = new java.util.HashMap<>();
+        Map<UUID, VirtualEntity> viewerLabels = new java.util.HashMap<>();
         viewerLabels.put(sharerId, null);
         renderManager.getLabelEntities().put(viewerId, viewerLabels);
 
@@ -68,7 +70,7 @@ class RenderManagerSharedCacheTest {
 
         renderManager.getSharedColors().put(sharerId, Color.RED);
         renderManager.getLabelComponentNames().put(sharerId, "Sharer");
-        Map<UUID, me.tofaa.entitylib.wrapper.WrapperEntity> viewerLabels = new java.util.HashMap<>();
+        Map<UUID, VirtualEntity> viewerLabels = new java.util.HashMap<>();
         viewerLabels.put(sharerId, null);
         renderManager.getLabelEntities().put(viewerId, viewerLabels);
 
@@ -87,7 +89,7 @@ class RenderManagerSharedCacheTest {
 
         renderManager.getSharedColors().put(sharerId, Color.RED);
         renderManager.getLabelComponentNames().put(sharerId, "Sharer");
-        Map<UUID, me.tofaa.entitylib.wrapper.WrapperEntity> viewerLabels = new java.util.HashMap<>();
+        Map<UUID, VirtualEntity> viewerLabels = new java.util.HashMap<>();
         viewerLabels.put(sharerId, null);
         renderManager.getLabelEntities().put(viewerId, viewerLabels);
 

--- a/src/test/java/dev/twme/worldeditdisplay/display/renderer/RegionRendererTest.java
+++ b/src/test/java/dev/twme/worldeditdisplay/display/renderer/RegionRendererTest.java
@@ -1,0 +1,37 @@
+package dev.twme.worldeditdisplay.display.renderer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+class RegionRendererTest {
+
+    @Test
+    void rejectsDegenerateLineBelowShapeLibraryMinimumLength() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(1.0f, 2.0f, 3.0f),
+                new Vector3f(1.0005f, 2.0f, 3.0f));
+
+        assertFalse(RegionRenderer.isRenderableLine(line));
+    }
+
+    @Test
+    void acceptsLineAtShapeLibraryMinimumLength() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(1.0f, 2.0f, 3.0f),
+                new Vector3f(1.001f, 2.0f, 3.0f));
+
+        assertTrue(RegionRenderer.isRenderableLine(line));
+    }
+
+    @Test
+    void rejectsNonFiniteLine() {
+        RegionRenderer.Line line = new RegionRenderer.Line(
+                new Vector3f(Float.NaN, 2.0f, 3.0f),
+                new Vector3f(4.0f, 5.0f, 6.0f));
+
+        assertFalse(RegionRenderer.isRenderableLine(line));
+    }
+}


### PR DESCRIPTION
## Summary

- replace the shaded EntityLib rendering backend with [VirtualEntities v0.9.0](https://github.com/twme-ai/VirtualEntities)
- use the released [TextDisplayShapes 3.0.0](https://github.com/TWME-TW/TextDisplayShapes/releases/tag/v3.0.0) artifact from the official TWME Maven repository
- share one VirtualEntityManager and canonical VirtualViewer instances across selection shapes and labels
- close renderers and unregister PacketEvents listeners during plugin shutdown
- bump WorldEditDisplay to 2.5.0
- include the Java 17, api-version 1.19, and degenerate-line compatibility fixes from #61

This supersedes #61.

## Compatibility

The final shaded Paper and Spigot artifacts contain 224 VirtualEntities classes and no EntityLib classes. All classes target Java 17 (class major 61).

- Paper: 21/21 stable versions passed from 1.19.4 through 26.2
- Spigot: 24/24 exact versions passed from 1.19.4 through 26.2
- 225/225 selection-shape cases passed across cuboid, cylinder, ellipsoid, polygon, and polyhedron
- each case required positive server-side retained entity counts and client-observed text_display packets
- all 45 server logs were clear of plugin enable errors, renderer errors, replay/watchdog failures, and class/API version errors

The released 3.0.0 packet-module classes are byte-for-byte identical to the pre-release commit used for the full version matrix.

## Verification

- fresh Maven cache: `mvn -B -U clean verify` (Paper), 34/34 tests
- fresh Maven cache: `mvn -B -U -P spigot clean verify`, 34/34 tests
- Maven provenance confirms TextDisplayShapes from `twme-releases` and VirtualEntities from `jitpack`
- retained-render E2E verifies 72 reused lines with zero respawns/removals for unchanged geometry
- shared-label E2E verifies shapes and labels use the same client connection
